### PR TITLE
Restructure Global & Project Settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,36 @@
 
 ## Specific instructions
 
+### Project Settings Architecture
+
+Projects (including batch projects) maintain separate settings for each feature type:
+
+| Feature | Basic Settings ID | Advanced Settings ID | Enable Flag |
+|---------|-------------------|---------------------|-------------|
+| Translation | `defaultTranslationBasicSettingsId` | `defaultTranslationAdvancedSettingsId` | `isDefaultTranslationEnabled` |
+| Extraction | `defaultExtractionBasicSettingsId` | `defaultExtractionAdvancedSettingsId` | `isDefaultExtractionEnabled` |
+| Transcription | `defaultTranscriptionId` | — | `isDefaultTranscriptionEnabled` |
+
+**Generic Settings (Legacy):**
+- `defaultBasicSettingsId` and `defaultAdvancedSettingsId` exist for backward compatibility and data migration
+- These are NOT used by batch or project UI for feature-specific operations
+- Feature-specific settings should always be preferred
+
+**Enable Flags Behavior:**
+- `isDefaultXxxEnabled = true`: New items created within the project use the project's default settings for that feature
+- `isDefaultXxxEnabled = false`: New items created within the project use global settings (`GLOBAL_TRANSLATION_BASIC_SETTINGS_ID`, etc.)
+
+**Batch Settings:**
+- Batch projects always use their own feature-specific default settings for the shared settings UI
+- `isUseSharedSettings` (batch-level toggle in `useBatchSettingsStore`) controls whether all files use shared settings or individual file settings
+- Batch never falls back to global settings
+
+**Global Settings IDs:**
+- `GLOBAL_TRANSLATION_BASIC_SETTINGS_ID` / `GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID`
+- `GLOBAL_EXTRACTION_BASIC_SETTINGS_ID` / `GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID`
+- `GLOBAL_TRANSCRIPTION_SETTINGS_ID`
+- `GLOBAL_BASIC_SETTINGS_ID` / `GLOBAL_ADVANCED_SETTINGS_ID` exist for backward compatibility only and are NOT used for feature-specific operations
+
 ### Data Management & Migrations
 
 Given that the application's state is persisted locally in the user's browser via IndexedDB (Dexie.js), managing data schema changes is critical. Follow these guidelines strictly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,11 @@ Projects (including batch projects) maintain separate settings for each feature 
 **Enable Flags Behavior:**
 - `isDefaultXxxEnabled = true`: New items created within the project use the project's default settings for that feature
 - `isDefaultXxxEnabled = false`: New items created within the project use global settings (`GLOBAL_TRANSLATION_BASIC_SETTINGS_ID`, etc.)
+- **Exception for Batch:** Batch projects always use project defaults for new items, regardless of `isDefaultXxxEnabled` flag
 
 **Batch Settings:**
 - Batch projects always use their own feature-specific default settings for the shared settings UI
+- New items uploaded to batch always use project defaults (ignores `isDefaultXxxEnabled` flag)
 - `isUseSharedSettings` (batch-level toggle in `useBatchSettingsStore`) controls whether all files use shared settings or individual file settings
 - Batch never falls back to global settings
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,21 @@ const setIsMaxCompletionTokensAuto = (value: boolean) => setAdvancedSettingsValu
 This wrapper pattern is used across settings components (`translate`, `batch`, `extract-context`, etc.) to keep component code declarative while leveraging the centralized setters exposed by the stores.
 As with setters, these getters ensure each component interacts only with the relevant slice of settings, avoiding accidental cross-project state leaks.
 
+### Disabling UI components visually
+
+When a component or section needs to be visually disabled (e.g., for shared settings that apply to all files), use the Tailwind classes `pointer-events-none opacity-50`:
+
+```tsx
+<div className={cn("space-y-4", isSharedSettings && "pointer-events-none opacity-50")}>
+  {isSharedSettings && (
+    <p className="text-sm font-semibold">Shared Settings (Applied to all files)</p>
+  )}
+  <SettingsComponent />
+</div>
+```
+
+This pattern disables all pointer interactions and reduces opacity to indicate the disabled state while keeping the content visible for reference.
+
 ### Subtitle text encoding
 
 - Use `createUtf8SubtitleBlob(content, type)` from `src/lib/utils.ts` for all SRT/ASS/VTT downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ If you want to update the changelog, please use the same style. The intent is fo
 
 ## 2026
 
+### March 16
+
+- ⚙️ **Independent Feature Settings:** You can now enable custom default settings for Translation, Extraction, and Transcription independently from one another within your projects.
+- 🎛️ **Better Global Settings:** The User Settings panel has been reorganized with dedicated buttons to easily configure your global defaults for each tool individually.
+
 ### March 6
 
 - 🤖 **Model Updates:**

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -100,7 +100,7 @@ export function UserSettings() {
                 Auto-enable custom default settings for new projects
               </Label>
               <p className="text-xs text-muted-foreground max-w-lg">
-                When enabled, the "Enable Settings" option for translation, extraction, and transcription will be automatically turned on for newly created projects.
+                When enabled, the "Enable Settings" option for translation, extraction, and transcription will be automatically turned on for new projects. New batch projects are always turned on.
               </p>
             </div>
             <Switch

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -31,8 +31,8 @@ export function UserSettings() {
   const toggleThirdPartyModel = useLocalSettingsStore((state) => state.toggleThirdPartyModel)
   const isSubtitlePerformanceModeEnabled = useLocalSettingsStore((state) => state.isSubtitlePerformanceModeEnabled)
   const setIsSubtitlePerformanceModeEnabled = useLocalSettingsStore((state) => state.setIsSubtitlePerformanceModeEnabled)
-  const isDefaultSettingsEnabledDefault = useLocalSettingsStore((state) => state.isDefaultSettingsEnabledDefault)
-  const setIsDefaultSettingsEnabledDefault = useLocalSettingsStore((state) => state.setIsDefaultSettingsEnabledDefault)
+  const isAutoEnableProjectSettings = useLocalSettingsStore((state) => state.isAutoEnableProjectSettings)
+  const setIsAutoEnableProjectSettings = useLocalSettingsStore((state) => state.setIsAutoEnableProjectSettings)
   const [isThirdPartyDialogOpen, setIsThirdPartyDialogOpen] = useState(false)
   const [isGlobalTranslationSettingsOpen, setIsGlobalTranslationSettingsOpen] = useState(false)
   const [isGlobalExtractionSettingsOpen, setIsGlobalExtractionSettingsOpen] = useState(false)
@@ -105,8 +105,8 @@ export function UserSettings() {
             </div>
             <Switch
               id="default-settings-enabled-default-switch"
-              checked={isDefaultSettingsEnabledDefault}
-              onCheckedChange={setIsDefaultSettingsEnabledDefault}
+              checked={isAutoEnableProjectSettings}
+              onCheckedChange={setIsAutoEnableProjectSettings}
             />
           </div>
 

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -5,7 +5,14 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { SettingsDialogue } from "@/components/settings-dialogue"
-import { GLOBAL_ADVANCED_SETTINGS_ID, GLOBAL_BASIC_SETTINGS_ID } from "@/constants/global-settings"
+import {
+  GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID,
+  GLOBAL_EXTRACTION_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID,
+  GLOBAL_TRANSLATION_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSCRIPTION_SETTINGS_ID
+} from "@/constants/global-settings"
+import { TranscriptionSettingsDialogue } from "@/components/transcribe/transcription-settings-dialogue"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,12 +29,12 @@ import { Settings2 } from "lucide-react"
 export function UserSettings() {
   const isThirdPartyModelEnabled = useLocalSettingsStore((state) => state.isThirdPartyModelEnabled)
   const toggleThirdPartyModel = useLocalSettingsStore((state) => state.toggleThirdPartyModel)
-  const isSeparateSettingsEnabled = useLocalSettingsStore((state) => state.isSeparateSettingsEnabled)
-  const setIsSeparateSettingsEnabled = useLocalSettingsStore((state) => state.setIsSeparateSettingsEnabled)
   const isSubtitlePerformanceModeEnabled = useLocalSettingsStore((state) => state.isSubtitlePerformanceModeEnabled)
   const setIsSubtitlePerformanceModeEnabled = useLocalSettingsStore((state) => state.setIsSubtitlePerformanceModeEnabled)
   const [isThirdPartyDialogOpen, setIsThirdPartyDialogOpen] = useState(false)
-  const [isGlobalDefaultsOpen, setIsGlobalDefaultsOpen] = useState(false)
+  const [isGlobalTranslationSettingsOpen, setIsGlobalTranslationSettingsOpen] = useState(false)
+  const [isGlobalExtractionSettingsOpen, setIsGlobalExtractionSettingsOpen] = useState(false)
+  const [isGlobalTranscriptionSettingsOpen, setIsGlobalTranscriptionSettingsOpen] = useState(false)
 
   const handleCheckedChange = (checked: boolean) => {
     if (checked) {
@@ -49,16 +56,31 @@ export function UserSettings() {
   return (
     <>
       <div className="rounded-md overflow-hidden border">
-        <div className="px-4 py-2 border-b flex items-center justify-between">
+        <div className="px-4 py-2 border-b flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <h2 className="font-medium">User Settings</h2>
-          <Button
-            variant="outline"
-            id="configure-global-defaults-button"
-            onClick={() => setIsGlobalDefaultsOpen(true)}
-          >
-            <Settings2 className="h-4 w-4" />
-            Global Settings
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setIsGlobalTranslationSettingsOpen(true)}
+            >
+              <Settings2 className="h-4 w-4 mr-2" />
+              Global Translation
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setIsGlobalTranscriptionSettingsOpen(true)}
+            >
+              <Settings2 className="h-4 w-4 mr-2" />
+              Global Transcription
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setIsGlobalExtractionSettingsOpen(true)}
+            >
+              <Settings2 className="h-4 w-4 mr-2" />
+              Global Extraction
+            </Button>
+          </div>
         </div>
         <div className="p-4 space-y-4">
           <div className="flex items-center justify-between gap-2">
@@ -76,21 +98,7 @@ export function UserSettings() {
               onCheckedChange={handleCheckedChange}
             />
           </div>
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex flex-col gap-2">
-              <Label>
-                Separate Default Settings
-              </Label>
-              <p className="text-xs text-muted-foreground max-w-lg">
-                Use distinct default settings for translation and context extraction instead of the default project settings. This will also separate sharing settings in batch projects.
-              </p>
-            </div>
-            <Switch
-              id="separate-settings-switch"
-              checked={isSeparateSettingsEnabled}
-              onCheckedChange={setIsSeparateSettingsEnabled}
-            />
-          </div>
+
           <div className="flex items-center justify-between gap-2">
             <div className="flex flex-col gap-2">
               <Label>
@@ -110,11 +118,28 @@ export function UserSettings() {
       </div>
       <SettingsDialogue
         isGlobal
-        isOpen={isGlobalDefaultsOpen}
-        onOpenChange={setIsGlobalDefaultsOpen}
-        projectName="Global Settings"
-        basicSettingsId={GLOBAL_BASIC_SETTINGS_ID}
-        advancedSettingsId={GLOBAL_ADVANCED_SETTINGS_ID}
+        isOpen={isGlobalTranslationSettingsOpen}
+        onOpenChange={setIsGlobalTranslationSettingsOpen}
+        projectName="Global Translation Settings"
+        basicSettingsId={GLOBAL_TRANSLATION_BASIC_SETTINGS_ID}
+        advancedSettingsId={GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID}
+        settingsParentType="translation"
+      />
+      <TranscriptionSettingsDialogue
+        isGlobal
+        isOpen={isGlobalTranscriptionSettingsOpen}
+        onOpenChange={setIsGlobalTranscriptionSettingsOpen}
+        projectName="Global Transcription Settings"
+        defaultTranscriptionId={GLOBAL_TRANSCRIPTION_SETTINGS_ID}
+      />
+      <SettingsDialogue
+        isGlobal
+        isOpen={isGlobalExtractionSettingsOpen}
+        onOpenChange={setIsGlobalExtractionSettingsOpen}
+        projectName="Global Extraction Settings"
+        basicSettingsId={GLOBAL_EXTRACTION_BASIC_SETTINGS_ID}
+        advancedSettingsId={GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID}
+        settingsParentType="extraction"
       />
       <AlertDialog open={isThirdPartyDialogOpen} onOpenChange={setIsThirdPartyDialogOpen}>
         <AlertDialogContent>

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -118,10 +118,10 @@ export function UserSettings() {
           <div className="flex items-center justify-between gap-2">
             <div className="flex flex-col gap-2">
               <Label>
-                Enable default settings for new projects
+                Auto-enable project settings for new projects
               </Label>
               <p className="text-xs text-muted-foreground max-w-lg">
-                When enabled, new projects will have their individual "Enable Default" switches turned on by default for translation, extraction, and transcription.
+                When enabled, the "Enable Settings" option for translation, extraction, and transcription will be automatically turned on for newly created projects.
               </p>
             </div>
             <Switch

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -114,6 +114,22 @@ export function UserSettings() {
               onCheckedChange={(checked) => setIsSubtitlePerformanceModeEnabled(!checked)}
             />
           </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-2">
+              <Label>
+                Enable default settings for new projects
+              </Label>
+              <p className="text-xs text-muted-foreground max-w-lg">
+                When enabled, new projects will have their individual "Enable Default" switches turned on by default for translation, extraction, and transcription.
+              </p>
+            </div>
+            <Switch
+              id="default-settings-enabled-default-switch"
+              checked={useLocalSettingsStore((state) => state.isDefaultSettingsEnabledDefault)}
+              onCheckedChange={(checked) => useLocalSettingsStore.getState().setIsDefaultSettingsEnabledDefault(checked)}
+            />
+          </div>
         </div>
       </div>
       <SettingsDialogue

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -56,31 +56,8 @@ export function UserSettings() {
   return (
     <>
       <div className="rounded-md overflow-hidden border">
-        <div className="px-4 py-2 border-b flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+        <div className="px-4 py-2 border-b">
           <h2 className="font-medium">User Settings</h2>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setIsGlobalTranslationSettingsOpen(true)}
-            >
-              <Settings2 className="h-4 w-4 mr-2" />
-              Global Translation
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => setIsGlobalTranscriptionSettingsOpen(true)}
-            >
-              <Settings2 className="h-4 w-4 mr-2" />
-              Global Transcription
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => setIsGlobalExtractionSettingsOpen(true)}
-            >
-              <Settings2 className="h-4 w-4 mr-2" />
-              Global Extraction
-            </Button>
-          </div>
         </div>
         <div className="p-4 space-y-4">
           <div className="flex items-center justify-between gap-2">
@@ -129,6 +106,60 @@ export function UserSettings() {
               checked={useLocalSettingsStore((state) => state.isDefaultSettingsEnabledDefault)}
               onCheckedChange={(checked) => useLocalSettingsStore.getState().setIsDefaultSettingsEnabledDefault(checked)}
             />
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-2">
+              <Label>
+                Global Translation Settings
+              </Label>
+              <p className="text-xs text-muted-foreground max-w-lg">
+                Configure default translation settings that apply to all new projects.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => setIsGlobalTranslationSettingsOpen(true)}
+            >
+              <Settings2 className="h-4 w-4" />
+              Configure
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-2">
+              <Label>
+                Global Transcription Settings
+              </Label>
+              <p className="text-xs text-muted-foreground max-w-lg">
+                Configure default transcription settings that apply to all new projects.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => setIsGlobalTranscriptionSettingsOpen(true)}
+            >
+              <Settings2 className="h-4 w-4" />
+              Configure
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-2">
+              <Label>
+                Global Extraction Settings
+              </Label>
+              <p className="text-xs text-muted-foreground max-w-lg">
+                Configure default extraction settings that apply to all new projects.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => setIsGlobalExtractionSettingsOpen(true)}
+            >
+              <Settings2 className="h-4 w-4" />
+              Configure
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -95,7 +95,7 @@ export function UserSettings() {
           <div className="flex items-center justify-between gap-2">
             <div className="flex flex-col gap-2">
               <Label>
-                Auto-enable project settings for new projects
+                Auto-enable custom default settings for new projects
               </Label>
               <p className="text-xs text-muted-foreground max-w-lg">
                 When enabled, the "Enable Settings" option for translation, extraction, and transcription will be automatically turned on for newly created projects.

--- a/src/components/auth/user-settings.tsx
+++ b/src/components/auth/user-settings.tsx
@@ -31,6 +31,8 @@ export function UserSettings() {
   const toggleThirdPartyModel = useLocalSettingsStore((state) => state.toggleThirdPartyModel)
   const isSubtitlePerformanceModeEnabled = useLocalSettingsStore((state) => state.isSubtitlePerformanceModeEnabled)
   const setIsSubtitlePerformanceModeEnabled = useLocalSettingsStore((state) => state.setIsSubtitlePerformanceModeEnabled)
+  const isDefaultSettingsEnabledDefault = useLocalSettingsStore((state) => state.isDefaultSettingsEnabledDefault)
+  const setIsDefaultSettingsEnabledDefault = useLocalSettingsStore((state) => state.setIsDefaultSettingsEnabledDefault)
   const [isThirdPartyDialogOpen, setIsThirdPartyDialogOpen] = useState(false)
   const [isGlobalTranslationSettingsOpen, setIsGlobalTranslationSettingsOpen] = useState(false)
   const [isGlobalExtractionSettingsOpen, setIsGlobalExtractionSettingsOpen] = useState(false)
@@ -103,8 +105,8 @@ export function UserSettings() {
             </div>
             <Switch
               id="default-settings-enabled-default-switch"
-              checked={useLocalSettingsStore((state) => state.isDefaultSettingsEnabledDefault)}
-              onCheckedChange={(checked) => useLocalSettingsStore.getState().setIsDefaultSettingsEnabledDefault(checked)}
+              checked={isDefaultSettingsEnabledDefault}
+              onCheckedChange={setIsDefaultSettingsEnabledDefault}
             />
           </div>
 

--- a/src/components/batch/batch-main.tsx
+++ b/src/components/batch/batch-main.tsx
@@ -50,21 +50,11 @@ export default function BatchMain({ basicSettingsId, advancedSettingsId }: Batch
   const setCurrentProject = useProjectStore((state) => state.setCurrentProject)
   const renameProject = useProjectStore((state) => state.renameProject)
 
-  const isSeparateSettingsEnabled = useLocalSettingsStore((state) => state.isSeparateSettingsEnabled)
+  const translationBasicSettingsId = currentProject?.defaultTranslationBasicSettingsId || basicSettingsId
+  const translationAdvancedSettingsId = currentProject?.defaultTranslationAdvancedSettingsId || advancedSettingsId
 
-  const translationBasicSettingsId = isSeparateSettingsEnabled
-    ? currentProject?.defaultTranslationBasicSettingsId || basicSettingsId
-    : basicSettingsId
-  const translationAdvancedSettingsId = isSeparateSettingsEnabled
-    ? currentProject?.defaultTranslationAdvancedSettingsId || advancedSettingsId
-    : advancedSettingsId
-
-  const extractionBasicSettingsId = isSeparateSettingsEnabled
-    ? currentProject?.defaultExtractionBasicSettingsId || basicSettingsId
-    : basicSettingsId
-  const extractionAdvancedSettingsId = isSeparateSettingsEnabled
-    ? currentProject?.defaultExtractionAdvancedSettingsId || advancedSettingsId
-    : advancedSettingsId
+  const extractionBasicSettingsId = currentProject?.defaultExtractionBasicSettingsId || basicSettingsId
+  const extractionAdvancedSettingsId = currentProject?.defaultExtractionAdvancedSettingsId || advancedSettingsId
 
   const handleBatchNameChange = (value: string) => {
     if (currentProject?.id && value.trim()) {

--- a/src/components/batch/batch-main.tsx
+++ b/src/components/batch/batch-main.tsx
@@ -35,12 +35,7 @@ import { BatchTranslationView } from "./batch-translation-view"
 import { BatchExtractionView } from "./batch-extraction-view"
 import { BatchTranscriptionView } from "./batch-transcription-view"
 
-interface BatchMainProps {
-  basicSettingsId: string
-  advancedSettingsId: string
-}
-
-export default function BatchMain({ basicSettingsId, advancedSettingsId }: BatchMainProps) {
+export default function BatchMain() {
   const [operationMode, setOperationMode] = useState<"translation" | "extraction" | "transcription">("translation")
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
@@ -50,11 +45,11 @@ export default function BatchMain({ basicSettingsId, advancedSettingsId }: Batch
   const setCurrentProject = useProjectStore((state) => state.setCurrentProject)
   const renameProject = useProjectStore((state) => state.renameProject)
 
-  const translationBasicSettingsId = currentProject?.defaultTranslationBasicSettingsId || basicSettingsId
-  const translationAdvancedSettingsId = currentProject?.defaultTranslationAdvancedSettingsId || advancedSettingsId
+  const translationBasicSettingsId = currentProject?.defaultTranslationBasicSettingsId
+  const translationAdvancedSettingsId = currentProject?.defaultTranslationAdvancedSettingsId
 
-  const extractionBasicSettingsId = currentProject?.defaultExtractionBasicSettingsId || basicSettingsId
-  const extractionAdvancedSettingsId = currentProject?.defaultExtractionAdvancedSettingsId || advancedSettingsId
+  const extractionBasicSettingsId = currentProject?.defaultExtractionBasicSettingsId
+  const extractionAdvancedSettingsId = currentProject?.defaultExtractionAdvancedSettingsId
 
   const handleBatchNameChange = (value: string) => {
     if (currentProject?.id && value.trim()) {
@@ -140,13 +135,13 @@ export default function BatchMain({ basicSettingsId, advancedSettingsId }: Batch
       </div>
 
       {/* Main Content */}
-      {operationMode === 'translation' && (
+      {operationMode === 'translation' && translationBasicSettingsId && translationAdvancedSettingsId && (
         <BatchTranslationView
           basicSettingsId={translationBasicSettingsId}
           advancedSettingsId={translationAdvancedSettingsId}
         />
       )}
-      {operationMode === 'extraction' && (
+      {operationMode === 'extraction' && extractionBasicSettingsId && extractionAdvancedSettingsId && (
         <BatchExtractionView
           basicSettingsId={extractionBasicSettingsId}
           advancedSettingsId={extractionAdvancedSettingsId}

--- a/src/components/batch/batch.tsx
+++ b/src/components/batch/batch.tsx
@@ -180,14 +180,5 @@ export default function Batch() {
     )
   }
 
-  if (!batch.defaultBasicSettingsId || !batch.defaultAdvancedSettingsId) {
-    return <div className="p-4">Invalid settings data</div>
-  }
-
-  return (
-    <BatchMain
-      basicSettingsId={batch.defaultBasicSettingsId}
-      advancedSettingsId={batch.defaultAdvancedSettingsId}
-    />
-  )
+  return <BatchMain />
 }

--- a/src/components/project/project-main.tsx
+++ b/src/components/project/project-main.tsx
@@ -28,6 +28,7 @@ import {
   ArrowLeft,
   ArrowLeftRight,
   Upload,
+  Plus,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -408,7 +409,6 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
     <Button
       size="sm"
       variant="outline"
-      className="line-clamp-2"
       onClick={async () => {
         const created = await createTranslationDb(
           currentProject.id,
@@ -431,6 +431,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         setTranslations(prev => [created, ...prev])
       }}
     >
+      <Plus className="h-4 w-4" />
       New Translation
     </Button>
   )
@@ -440,11 +441,11 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       <Button
         size="sm"
         variant="outline"
-        className="h-8 w-8 p-0"
         onClick={() => setIsTranslationSettingsModalOpen(true)}
         title="Translation settings"
       >
         <Settings2 className="h-4 w-4" />
+        Settings
       </Button>
       {NewTranslationButton}
     </div>
@@ -454,7 +455,6 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
     <Button
       size="sm"
       variant="outline"
-      className="line-clamp-2"
       onClick={async () => {
         const defaultSettings = transcriptionData[currentProject.defaultTranscriptionId]
         const created = await createTranscriptionDb(currentProject.id, {
@@ -474,6 +474,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         setTranscriptions(prev => [created, ...prev])
       }}
     >
+      <Plus className="h-4 w-4" />
       New Transcription
     </Button>
   )
@@ -483,11 +484,11 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       <Button
         size="sm"
         variant="outline"
-        className="h-8 w-8 p-0"
         onClick={() => setIsTranscriptionSettingsModalOpen(true)}
         title="Transcription settings"
       >
         <Settings2 className="h-4 w-4" />
+        Settings
       </Button>
       {NewTranscriptionButton}
     </div>
@@ -497,7 +498,6 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
     <Button
       size="sm"
       variant="outline"
-      className="line-clamp-2"
       onClick={async () => {
         const created = await createExtractionDb(
           currentProject.id,
@@ -519,6 +519,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         setExtractions(prev => [created, ...prev])
       }}
     >
+      <Plus className="h-4 w-4" />
       New Extraction
     </Button>
   )
@@ -528,11 +529,11 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       <Button
         size="sm"
         variant="outline"
-        className="h-8 w-8 p-0"
         onClick={() => setIsExtractionSettingsModalOpen(true)}
         title="Extraction settings"
       >
         <Settings2 className="h-4 w-4" />
+        Settings
       </Button>
       {NewExtractionButton}
     </div>

--- a/src/components/project/project-main.tsx
+++ b/src/components/project/project-main.tsx
@@ -456,17 +456,10 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       size="sm"
       variant="outline"
       onClick={async () => {
-        const defaultSettings = currentProject.isDefaultTranscriptionEnabled
-          ? transcriptionData[currentProject.defaultTranscriptionId]
-          : transcriptionData[GLOBAL_TRANSCRIPTION_SETTINGS_ID]
         const created = await createTranscriptionDb(currentProject.id, {
           title: `Audio ${new Date().toLocaleDateString()} ${crypto.randomUUID().slice(0, 5)}`,
           transcriptionText: "",
           transcriptSubtitles: [],
-          models: defaultSettings?.models,
-          language: defaultSettings?.language,
-          selectedMode: defaultSettings?.selectedMode,
-          customInstructions: defaultSettings?.customInstructions,
         })
         {
           const storeProject = useProjectStore.getState().currentProject

--- a/src/components/project/project-main.tsx
+++ b/src/components/project/project-main.tsx
@@ -456,7 +456,9 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       size="sm"
       variant="outline"
       onClick={async () => {
-        const defaultSettings = transcriptionData[currentProject.defaultTranscriptionId]
+        const defaultSettings = currentProject.isDefaultTranscriptionEnabled
+          ? transcriptionData[currentProject.defaultTranscriptionId]
+          : transcriptionData[GLOBAL_TRANSCRIPTION_SETTINGS_ID]
         const created = await createTranscriptionDb(currentProject.id, {
           title: `Audio ${new Date().toLocaleDateString()} ${crypto.randomUUID().slice(0, 5)}`,
           transcriptionText: "",

--- a/src/components/project/project-main.tsx
+++ b/src/components/project/project-main.tsx
@@ -51,7 +51,8 @@ import {
   GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID,
   GLOBAL_EXTRACTION_BASIC_SETTINGS_ID,
   GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID,
-  GLOBAL_TRANSLATION_BASIC_SETTINGS_ID
+  GLOBAL_TRANSLATION_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSCRIPTION_SETTINGS_ID,
 } from "@/constants/global-settings"
 import { exportProject } from "@/lib/db/db-io"
 import { toast } from "sonner"
@@ -89,6 +90,9 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
   const [isTranslationSettingsModalOpen, setIsTranslationSettingsModalOpen] = useState(false)
   const [isExtractionSettingsModalOpen, setIsExtractionSettingsModalOpen] = useState(false)
   const [isTranscriptionSettingsModalOpen, setIsTranscriptionSettingsModalOpen] = useState(false)
+  const [isGlobalTranslationSettingsOpen, setIsGlobalTranslationSettingsOpen] = useState(false)
+  const [isGlobalExtractionSettingsOpen, setIsGlobalExtractionSettingsOpen] = useState(false)
+  const [isGlobalTranscriptionSettingsOpen, setIsGlobalTranscriptionSettingsOpen] = useState(false)
   const [isConvertModalOpen, setIsConvertModalOpen] = useState(false)
   const [isProcessingConvert, setIsProcessingConvert] = useState(false)
   const router = useRouter()
@@ -638,6 +642,12 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         resetFromBasicSettingsId={GLOBAL_TRANSLATION_BASIC_SETTINGS_ID}
         resetFromAdvancedSettingsId={GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID}
         settingsParentType="translation"
+        isDefaultEnabled={currentProject.isDefaultTranslationEnabled}
+        onDefaultEnabledChange={(enabled) => updateProjectStore(currentProject.id, { isDefaultTranslationEnabled: enabled })}
+        onOpenGlobalSettings={() => {
+          setIsTranslationSettingsModalOpen(false)
+          setIsGlobalTranslationSettingsOpen(true)
+        }}
       />
 
       <SettingsDialogue
@@ -649,6 +659,12 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         resetFromBasicSettingsId={GLOBAL_EXTRACTION_BASIC_SETTINGS_ID}
         resetFromAdvancedSettingsId={GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID}
         settingsParentType="extraction"
+        isDefaultEnabled={currentProject.isDefaultExtractionEnabled}
+        onDefaultEnabledChange={(enabled) => updateProjectStore(currentProject.id, { isDefaultExtractionEnabled: enabled })}
+        onOpenGlobalSettings={() => {
+          setIsExtractionSettingsModalOpen(false)
+          setIsGlobalExtractionSettingsOpen(true)
+        }}
       />
 
       <TranscriptionSettingsDialogue
@@ -656,6 +672,39 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         onOpenChange={setIsTranscriptionSettingsModalOpen}
         projectName={currentProject.name}
         defaultTranscriptionId={currentProject.defaultTranscriptionId}
+        isDefaultEnabled={currentProject.isDefaultTranscriptionEnabled}
+        onDefaultEnabledChange={(enabled) => updateProjectStore(currentProject.id, { isDefaultTranscriptionEnabled: enabled })}
+        onOpenGlobalSettings={() => {
+          setIsTranscriptionSettingsModalOpen(false)
+          setIsGlobalTranscriptionSettingsOpen(true)
+        }}
+      />
+
+      {/* Global Settings Dialogues */}
+      <SettingsDialogue
+        isGlobal
+        isOpen={isGlobalTranslationSettingsOpen}
+        onOpenChange={setIsGlobalTranslationSettingsOpen}
+        projectName="Global Translation"
+        basicSettingsId={GLOBAL_TRANSLATION_BASIC_SETTINGS_ID}
+        advancedSettingsId={GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID}
+      />
+
+      <SettingsDialogue
+        isGlobal
+        isOpen={isGlobalExtractionSettingsOpen}
+        onOpenChange={setIsGlobalExtractionSettingsOpen}
+        projectName="Global Extraction"
+        basicSettingsId={GLOBAL_EXTRACTION_BASIC_SETTINGS_ID}
+        advancedSettingsId={GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID}
+      />
+
+      <TranscriptionSettingsDialogue
+        isGlobal
+        isOpen={isGlobalTranscriptionSettingsOpen}
+        onOpenChange={setIsGlobalTranscriptionSettingsOpen}
+        projectName="Global Transcription"
+        defaultTranscriptionId={GLOBAL_TRANSCRIPTION_SETTINGS_ID}
       />
 
       {/* Convert Confirmation Dialog */}

--- a/src/components/project/project-main.tsx
+++ b/src/components/project/project-main.tsx
@@ -47,6 +47,12 @@ import { useTranscriptionStore } from "@/stores/services/use-transcription-store
 import { useLocalSettingsStore } from "@/stores/use-local-settings-store"
 import { SettingsDialogue } from "../settings-dialogue"
 import { TranscriptionSettingsDialogue } from "../transcribe/transcription-settings-dialogue"
+import {
+  GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID,
+  GLOBAL_EXTRACTION_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID,
+  GLOBAL_TRANSLATION_BASIC_SETTINGS_ID
+} from "@/constants/global-settings"
 import { exportProject } from "@/lib/db/db-io"
 import { toast } from "sonner"
 import { Badge } from "../ui/badge"
@@ -80,15 +86,12 @@ interface ProjectMainProps {
 export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isTranslationSettingsModalOpen, setIsTranslationSettingsModalOpen] = useState(false)
   const [isExtractionSettingsModalOpen, setIsExtractionSettingsModalOpen] = useState(false)
   const [isTranscriptionSettingsModalOpen, setIsTranscriptionSettingsModalOpen] = useState(false)
   const [isConvertModalOpen, setIsConvertModalOpen] = useState(false)
   const [isProcessingConvert, setIsProcessingConvert] = useState(false)
   const router = useRouter()
-
-  const isSeparateSettingsEnabled = useLocalSettingsStore((state) => state.isSeparateSettingsEnabled)
 
   const renameProject = useProjectStore((state) => state.renameProject)
   const deleteProject = useProjectStore((state) => state.deleteProject)
@@ -430,17 +433,15 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
 
   const NewTranslationControls = (
     <div className="flex items-center gap-2">
-      {isSeparateSettingsEnabled && (
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 w-8 p-0"
-          onClick={() => setIsTranslationSettingsModalOpen(true)}
-          title="Translation settings"
-        >
-          <Settings2 className="h-4 w-4" />
-        </Button>
-      )}
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-8 w-8 p-0"
+        onClick={() => setIsTranslationSettingsModalOpen(true)}
+        title="Translation settings"
+      >
+        <Settings2 className="h-4 w-4" />
+      </Button>
       {NewTranslationButton}
     </div>
   )
@@ -451,9 +452,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       variant="outline"
       className="line-clamp-2"
       onClick={async () => {
-        const defaultSettings = isSeparateSettingsEnabled
-          ? transcriptionData[currentProject.defaultTranscriptionId]
-          : undefined
+        const defaultSettings = transcriptionData[currentProject.defaultTranscriptionId]
         const created = await createTranscriptionDb(currentProject.id, {
           title: `Audio ${new Date().toLocaleDateString()} ${crypto.randomUUID().slice(0, 5)}`,
           transcriptionText: "",
@@ -477,17 +476,15 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
 
   const NewTranscriptionControls = (
     <div className="flex items-center gap-2">
-      {isSeparateSettingsEnabled && (
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 w-8 p-0"
-          onClick={() => setIsTranscriptionSettingsModalOpen(true)}
-          title="Transcription settings"
-        >
-          <Settings2 className="h-4 w-4" />
-        </Button>
-      )}
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-8 w-8 p-0"
+        onClick={() => setIsTranscriptionSettingsModalOpen(true)}
+        title="Transcription settings"
+      >
+        <Settings2 className="h-4 w-4" />
+      </Button>
       {NewTranscriptionButton}
     </div>
   )
@@ -524,17 +521,15 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
 
   const NewExtractionControls = (
     <div className="flex items-center gap-2">
-      {isSeparateSettingsEnabled && (
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 w-8 p-0"
-          onClick={() => setIsExtractionSettingsModalOpen(true)}
-          title="Extraction settings"
-        >
-          <Settings2 className="h-4 w-4" />
-        </Button>
-      )}
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-8 w-8 p-0"
+        onClick={() => setIsExtractionSettingsModalOpen(true)}
+        title="Extraction settings"
+      >
+        <Settings2 className="h-4 w-4" />
+      </Button>
       {NewExtractionButton}
     </div>
   )
@@ -594,13 +589,6 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
               Rename
             </button>
             <button
-              onClick={() => setIsSettingsModalOpen(true)}
-              className="flex items-center gap-2 hover:underline"
-            >
-              <Settings2 size={4 * 5} />
-              Settings
-            </button>
-            <button
               onClick={handleExportProject}
               className="flex items-center gap-2 hover:underline"
             >
@@ -642,21 +630,13 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       />
 
       <SettingsDialogue
-        isOpen={isSettingsModalOpen}
-        onOpenChange={setIsSettingsModalOpen}
-        projectName={currentProject.name}
-        basicSettingsId={currentProject.defaultBasicSettingsId}
-        advancedSettingsId={currentProject.defaultAdvancedSettingsId}
-      />
-
-      <SettingsDialogue
         isOpen={isTranslationSettingsModalOpen}
         onOpenChange={setIsTranslationSettingsModalOpen}
         projectName={currentProject.name}
         basicSettingsId={currentProject.defaultTranslationBasicSettingsId}
         advancedSettingsId={currentProject.defaultTranslationAdvancedSettingsId}
-        resetFromBasicSettingsId={currentProject.defaultBasicSettingsId}
-        resetFromAdvancedSettingsId={currentProject.defaultAdvancedSettingsId}
+        resetFromBasicSettingsId={GLOBAL_TRANSLATION_BASIC_SETTINGS_ID}
+        resetFromAdvancedSettingsId={GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID}
         settingsParentType="translation"
       />
 
@@ -666,8 +646,8 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         projectName={currentProject.name}
         basicSettingsId={currentProject.defaultExtractionBasicSettingsId}
         advancedSettingsId={currentProject.defaultExtractionAdvancedSettingsId}
-        resetFromBasicSettingsId={currentProject.defaultBasicSettingsId}
-        resetFromAdvancedSettingsId={currentProject.defaultAdvancedSettingsId}
+        resetFromBasicSettingsId={GLOBAL_EXTRACTION_BASIC_SETTINGS_ID}
+        resetFromAdvancedSettingsId={GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID}
         settingsParentType="extraction"
       />
 

--- a/src/components/project/project-main.tsx
+++ b/src/components/project/project-main.tsx
@@ -46,6 +46,7 @@ import { useExtractionStore } from "@/stores/services/use-extraction-store"
 import { useTranscriptionStore } from "@/stores/services/use-transcription-store"
 import { useLocalSettingsStore } from "@/stores/use-local-settings-store"
 import { SettingsDialogue } from "../settings-dialogue"
+import { TranscriptionSettingsDialogue } from "../transcribe/transcription-settings-dialogue"
 import { exportProject } from "@/lib/db/db-io"
 import { toast } from "sonner"
 import { Badge } from "../ui/badge"
@@ -82,6 +83,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isTranslationSettingsModalOpen, setIsTranslationSettingsModalOpen] = useState(false)
   const [isExtractionSettingsModalOpen, setIsExtractionSettingsModalOpen] = useState(false)
+  const [isTranscriptionSettingsModalOpen, setIsTranscriptionSettingsModalOpen] = useState(false)
   const [isConvertModalOpen, setIsConvertModalOpen] = useState(false)
   const [isProcessingConvert, setIsProcessingConvert] = useState(false)
   const router = useRouter()
@@ -116,6 +118,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
   const deleteTranscriptionDb = useTranscriptionDataStore((state) => state.deleteTranscriptionDb)
   const getTranscriptionDb = useTranscriptionDataStore((state) => state.getTranscriptionDb)
   const getTranscriptionsDb = useTranscriptionDataStore((state) => state.getTranscriptionsDb)
+  const transcriptionData = useTranscriptionDataStore((state) => state.data)
 
   const isTranslatingSet = useTranslationStore(state => state.isTranslatingSet)
   const isExtractingSet = useExtractionStore(state => state.isExtractingSet)
@@ -131,10 +134,16 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
   useEffect(() => {
     const loadData = async () => {
       setIsLoadingData(true)
-      const [translationsData, transcriptionsData, extractionsData] = await Promise.all([
+      const [
+        translationsData,
+        transcriptionsData,
+        extractionsData,
+        _defaultTranscription,
+      ] = await Promise.all([
         getTranslationsDb(currentProject.translations),
         getTranscriptionsDb(currentProject.transcriptions),
-        getExtractionsDb(currentProject.extractions)
+        getExtractionsDb(currentProject.extractions),
+        getTranscriptionDb(currentProject.defaultTranscriptionId),
       ])
 
       setTranslations(translationsData.reverse())
@@ -442,10 +451,17 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
       variant="outline"
       className="line-clamp-2"
       onClick={async () => {
+        const defaultSettings = isSeparateSettingsEnabled
+          ? transcriptionData[currentProject.defaultTranscriptionId]
+          : undefined
         const created = await createTranscriptionDb(currentProject.id, {
           title: `Audio ${new Date().toLocaleDateString()} ${crypto.randomUUID().slice(0, 5)}`,
           transcriptionText: "",
-          transcriptSubtitles: []
+          transcriptSubtitles: [],
+          models: defaultSettings?.models,
+          language: defaultSettings?.language,
+          selectedMode: defaultSettings?.selectedMode,
+          customInstructions: defaultSettings?.customInstructions,
         })
         {
           const storeProject = useProjectStore.getState().currentProject
@@ -457,6 +473,23 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
     >
       New Transcription
     </Button>
+  )
+
+  const NewTranscriptionControls = (
+    <div className="flex items-center gap-2">
+      {isSeparateSettingsEnabled && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8 w-8 p-0"
+          onClick={() => setIsTranscriptionSettingsModalOpen(true)}
+          title="Transcription settings"
+        >
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      )}
+      {NewTranscriptionButton}
+    </div>
   )
 
   const NewExtractionButton = (
@@ -638,6 +671,13 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
         settingsParentType="extraction"
       />
 
+      <TranscriptionSettingsDialogue
+        isOpen={isTranscriptionSettingsModalOpen}
+        onOpenChange={setIsTranscriptionSettingsModalOpen}
+        projectName={currentProject.name}
+        defaultTranscriptionId={currentProject.defaultTranscriptionId}
+      />
+
       {/* Convert Confirmation Dialog */}
       <Dialog open={isConvertModalOpen} onOpenChange={setIsConvertModalOpen}>
         <DialogContent>
@@ -714,7 +754,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
             <div className="bg-card border border-border rounded-lg p-4">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium">Transcriptions</h3>
-                {NewTranscriptionButton}
+                {NewTranscriptionControls}
               </div>
               <DndContext
                 sensors={sensors}
@@ -784,7 +824,7 @@ export const ProjectMain = ({ currentProject }: ProjectMainProps) => {
           <div className="bg-card border border-border rounded-lg p-4">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-sm font-medium">All Transcriptions</h3>
-              {NewTranscriptionButton}
+              {NewTranscriptionControls}
             </div>
             <DndContext
               sensors={sensors}

--- a/src/components/settings-dialogue.tsx
+++ b/src/components/settings-dialogue.tsx
@@ -139,7 +139,7 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
           <div className="flex items-center justify-between gap-2 p-4 border rounded-md mb-4 bg-muted/20">
             <div className="flex flex-col gap-1">
               <Label htmlFor={`enable-default-${settingsParentType}`}>
-                Enable Default
+                Enable Settings
               </Label>
               <p className="text-xs text-muted-foreground">
                 When enabled, new {settingsParentType}s in this project will use these custom default settings. When disabled, they will use your Global settings.

--- a/src/components/settings-dialogue.tsx
+++ b/src/components/settings-dialogue.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Info } from "lucide-react"
+import { Info, Settings2 } from "lucide-react"
 import { DialogCustom } from "@/components/ui-custom/dialog-custom"
 import {
   DialogContent,
@@ -134,7 +134,7 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
           <DialogTitle>{dialogTitle}</DialogTitle>
           <DialogDescription>{dialogDescription}</DialogDescription>
         </DialogHeader>
-        
+
         {!isGlobal && settingsParentType !== 'project' && isDefaultEnabled !== undefined && onDefaultEnabledChange && (
           <div className="flex items-center justify-between gap-2 p-4 border rounded-md mb-4 bg-muted/20">
             <div className="flex flex-col gap-1">
@@ -245,6 +245,7 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
         <DialogFooter>
           {!isGlobal && settingsParentType !== 'project' && onOpenGlobalSettings && (
             <Button variant="outline" className="mr-auto" onClick={onOpenGlobalSettings}>
+              <Settings2 className="h-4 w-4" />
               Global Settings
             </Button>
           )}

--- a/src/components/settings-dialogue.tsx
+++ b/src/components/settings-dialogue.tsx
@@ -24,6 +24,8 @@ import {
   TemperatureSlider,
 } from "@/components/settings"
 import { Button } from "@/components/ui/button"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
 import {
   Accordion,
   AccordionContent,
@@ -55,6 +57,9 @@ interface SettingsDialogueProps {
   settingsParentType?: SettingsParentType
   resetFromBasicSettingsId?: string
   resetFromAdvancedSettingsId?: string
+  isDefaultEnabled?: boolean
+  onDefaultEnabledChange?: (enabled: boolean) => void
+  onOpenGlobalSettings?: () => void
 }
 
 export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
@@ -66,6 +71,9 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
   advancedSettingsId,
   resetFromBasicSettingsId,
   resetFromAdvancedSettingsId,
+  isDefaultEnabled,
+  onDefaultEnabledChange,
+  onOpenGlobalSettings,
   settingsParentType = 'project',
 }) => {
   const resetBasicSettings = useSettingsStore((s) => s.resetBasicSettings)
@@ -126,7 +134,26 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
           <DialogTitle>{dialogTitle}</DialogTitle>
           <DialogDescription>{dialogDescription}</DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
+        
+        {!isGlobal && settingsParentType !== 'project' && isDefaultEnabled !== undefined && onDefaultEnabledChange && (
+          <div className="flex items-center justify-between gap-2 p-4 border rounded-md mb-4 bg-muted/20">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor={`enable-default-${settingsParentType}`}>
+                Enable Default
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                When enabled, new {settingsParentType}s in this project will use these custom default settings. When disabled, they will use your Global settings.
+              </p>
+            </div>
+            <Switch
+              id={`enable-default-${settingsParentType}`}
+              checked={isDefaultEnabled}
+              onCheckedChange={onDefaultEnabledChange}
+            />
+          </div>
+        )}
+
+        <div className={`space-y-4 ${!isGlobal && settingsParentType !== 'project' && isDefaultEnabled === false ? 'opacity-50 pointer-events-none' : ''}`}>
           {settingsParentType === 'extraction' ? (
             <div className="space-y-4">
               <ModelSelection
@@ -216,6 +243,11 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
           )}
         </div>
         <DialogFooter>
+          {!isGlobal && settingsParentType !== 'project' && onOpenGlobalSettings && (
+            <Button variant="outline" className="mr-auto" onClick={onOpenGlobalSettings}>
+              Global Settings
+            </Button>
+          )}
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="outline">

--- a/src/components/settings-dialogue.tsx
+++ b/src/components/settings-dialogue.tsx
@@ -142,7 +142,7 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
                 Enable Settings
               </Label>
               <p className="text-xs text-muted-foreground">
-                When enabled, new {settingsParentType}s in this project will use these custom default settings. When disabled, they will use your Global settings.
+                When enabled, new {settingsParentType}s will use these custom default settings. When disabled, they will use your Global settings.
               </p>
             </div>
             <Switch

--- a/src/components/settings-dialogue.tsx
+++ b/src/components/settings-dialogue.tsx
@@ -43,7 +43,6 @@ import {
 } from "@/components/ui/alert-dialog"
 import { useSettingsStore } from "@/stores/settings/use-settings-store"
 import { useAdvancedSettingsStore } from "@/stores/settings/use-advanced-settings-store"
-import { useLocalSettingsStore } from "@/stores/use-local-settings-store"
 import { SettingsParentType } from "@/types/project"
 
 interface SettingsDialogueProps {
@@ -75,7 +74,6 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
   const resetAdvancedSettingsToGlobal = useAdvancedSettingsStore((s) => s.resetAdvancedSettingsToGlobal)
   const resetBasicSettingsFrom = useSettingsStore((s) => s.resetBasicSettingsFrom)
   const resetAdvancedSettingsFrom = useAdvancedSettingsStore((s) => s.resetAdvancedSettingsFrom)
-  const isSeparateSettingsEnabled = useLocalSettingsStore((s) => s.isSeparateSettingsEnabled)
 
   const dialogTitle = isGlobal
     ? "Global Settings"
@@ -218,14 +216,6 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
           )}
         </div>
         <DialogFooter>
-          {!isGlobal && settingsParentType === 'project' && isSeparateSettingsEnabled && (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <div className="h-3 w-3">
-                <Info className="h-3 w-3" />
-              </div>
-              This settings will not be used because "Separate Default Settings" is enabled.
-            </div>
-          )}
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="outline">
@@ -238,9 +228,7 @@ export const SettingsDialogue: React.FC<SettingsDialogueProps> = ({
                 <AlertDialogDescription>
                   {isGlobal
                     ? "This will reset settings to defaults."
-                    : settingsParentType === 'project'
-                      ? "This will reset to global settings."
-                      : "This will reset to project settings."
+                    : "This will reset to global settings."
                   }
                 </AlertDialogDescription>
               </AlertDialogHeader>

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect } from "react"
+import { DialogCustom } from "@/components/ui-custom/dialog-custom"
+import {
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { SettingsTranscription } from "./settings-transcription"
+import { useTranscriptionDataStore } from "@/stores/data/use-transcription-data-store"
+
+interface TranscriptionSettingsDialogueProps {
+  isOpen: boolean
+  onOpenChange: (isOpen: boolean) => void
+  projectName: string
+  defaultTranscriptionId: string
+}
+
+export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialogueProps> = ({
+  isOpen,
+  onOpenChange,
+  projectName,
+  defaultTranscriptionId,
+}) => {
+  const getTranscriptionDb = useTranscriptionDataStore((s) => s.getTranscriptionDb)
+  const data = useTranscriptionDataStore((s) => s.data)
+
+  useEffect(() => {
+    if (isOpen && !data[defaultTranscriptionId]) {
+      getTranscriptionDb(defaultTranscriptionId)
+    }
+  }, [isOpen, defaultTranscriptionId, data, getTranscriptionDb])
+
+  return (
+    <DialogCustom
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      modal={false}
+      fadeDuration={50}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Transcription Settings</DialogTitle>
+          <DialogDescription>
+            {`Default transcription settings for "${projectName}" will go here.`}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          {data[defaultTranscriptionId] ? (
+            <SettingsTranscription transcriptionId={defaultTranscriptionId} />
+          ) : (
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </DialogCustom>
+  )
+}

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -102,7 +102,7 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
                 Enable Settings
               </Label>
               <p className="text-xs text-muted-foreground">
-                When enabled, new transcriptions in this project will use these custom default settings. When disabled, they will use your Global Transcription Settings.
+                When enabled, new transcriptions will use these custom default settings. When disabled, they will use your Global Transcription Settings.
               </p>
             </div>
             <Switch

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -66,7 +66,7 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
           <div className="flex items-center justify-between gap-2 p-4 border rounded-md mb-4 bg-muted/20">
             <div className="flex flex-col gap-1">
               <Label htmlFor="enable-default-transcription">
-                Enable Default
+                Enable Settings
               </Label>
               <p className="text-xs text-muted-foreground">
                 When enabled, new transcriptions in this project will use these custom default settings. When disabled, they will use your Global Transcription Settings.

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -14,6 +14,19 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { SettingsTranscription } from "./settings-transcription"
 import { useTranscriptionDataStore } from "@/stores/data/use-transcription-data-store"
+import { GLOBAL_TRANSCRIPTION_SETTINGS_ID } from "@/constants/global-settings"
+import { DEFAULT_TRANSCRIPTION_SETTINGS } from "@/constants/default"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 
 interface TranscriptionSettingsDialogueProps {
   isOpen: boolean
@@ -37,7 +50,26 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
   onOpenGlobalSettings,
 }) => {
   const getTranscriptionDb = useTranscriptionDataStore((s) => s.getTranscriptionDb)
+  const updateTranscriptionDb = useTranscriptionDataStore((s) => s.updateTranscriptionDb)
+  const copyTranscriptionSettingsKeys = useTranscriptionDataStore((s) => s.copyTranscriptionSettingsKeys)
   const data = useTranscriptionDataStore((s) => s.data)
+
+  const handleResetAll = async () => {
+    if (isGlobal) {
+      await updateTranscriptionDb(defaultTranscriptionId, {
+        language: DEFAULT_TRANSCRIPTION_SETTINGS.language,
+        selectedMode: DEFAULT_TRANSCRIPTION_SETTINGS.selectedMode,
+        customInstructions: DEFAULT_TRANSCRIPTION_SETTINGS.customInstructions,
+        models: DEFAULT_TRANSCRIPTION_SETTINGS.models,
+      })
+    } else {
+      await copyTranscriptionSettingsKeys(
+        GLOBAL_TRANSCRIPTION_SETTINGS_ID,
+        defaultTranscriptionId,
+        ['language', 'selectedMode', 'customInstructions', 'models']
+      )
+    }
+  }
 
   useEffect(() => {
     if (isOpen && !data[defaultTranscriptionId]) {
@@ -93,6 +125,28 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
               Global Settings
             </Button>
           )}
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline">
+                Reset All
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Reset all settings?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {isGlobal
+                    ? "This will reset settings to defaults."
+                    : "This will reset to global settings."
+                  }
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleResetAll}>Reset</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
           <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -16,6 +16,7 @@ import { SettingsTranscription } from "./settings-transcription"
 import { useTranscriptionDataStore } from "@/stores/data/use-transcription-data-store"
 import { GLOBAL_TRANSCRIPTION_SETTINGS_ID } from "@/constants/global-settings"
 import { DEFAULT_TRANSCRIPTION_SETTINGS } from "@/constants/default"
+import { Settings2 } from "lucide-react"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -122,6 +123,7 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
         <DialogFooter>
           {!isGlobal && onOpenGlobalSettings && (
             <Button variant="outline" className="mr-auto" onClick={onOpenGlobalSettings}>
+              <Settings2 className="h-4 w-4" />
               Global Settings
             </Button>
           )}

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
 import { SettingsTranscription } from "./settings-transcription"
 import { useTranscriptionDataStore } from "@/stores/data/use-transcription-data-store"
 
@@ -19,6 +21,9 @@ interface TranscriptionSettingsDialogueProps {
   projectName: string
   defaultTranscriptionId: string
   isGlobal?: boolean
+  isDefaultEnabled?: boolean
+  onDefaultEnabledChange?: (enabled: boolean) => void
+  onOpenGlobalSettings?: () => void
 }
 
 export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialogueProps> = ({
@@ -27,6 +32,9 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
   projectName,
   defaultTranscriptionId,
   isGlobal,
+  isDefaultEnabled,
+  onDefaultEnabledChange,
+  onOpenGlobalSettings,
 }) => {
   const getTranscriptionDb = useTranscriptionDataStore((s) => s.getTranscriptionDb)
   const data = useTranscriptionDataStore((s) => s.data)
@@ -53,7 +61,26 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
               : `Default transcription settings for "${projectName}" will go here.`}
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
+
+        {!isGlobal && isDefaultEnabled !== undefined && onDefaultEnabledChange && (
+          <div className="flex items-center justify-between gap-2 p-4 border rounded-md mb-4 bg-muted/20">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="enable-default-transcription">
+                Enable Default
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                When enabled, new transcriptions in this project will use these custom default settings. When disabled, they will use your Global Transcription Settings.
+              </p>
+            </div>
+            <Switch
+              id="enable-default-transcription"
+              checked={isDefaultEnabled}
+              onCheckedChange={onDefaultEnabledChange}
+            />
+          </div>
+        )}
+
+        <div className={`space-y-4 ${!isGlobal && isDefaultEnabled === false ? 'opacity-50 pointer-events-none' : ''}`}>
           {data[defaultTranscriptionId] ? (
             <SettingsTranscription transcriptionId={defaultTranscriptionId} />
           ) : (
@@ -61,6 +88,11 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
           )}
         </div>
         <DialogFooter>
+          {!isGlobal && onOpenGlobalSettings && (
+            <Button variant="outline" className="mr-auto" onClick={onOpenGlobalSettings}>
+              Global Settings
+            </Button>
+          )}
           <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/transcribe/transcription-settings-dialogue.tsx
+++ b/src/components/transcribe/transcription-settings-dialogue.tsx
@@ -18,6 +18,7 @@ interface TranscriptionSettingsDialogueProps {
   onOpenChange: (isOpen: boolean) => void
   projectName: string
   defaultTranscriptionId: string
+  isGlobal?: boolean
 }
 
 export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialogueProps> = ({
@@ -25,6 +26,7 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
   onOpenChange,
   projectName,
   defaultTranscriptionId,
+  isGlobal,
 }) => {
   const getTranscriptionDb = useTranscriptionDataStore((s) => s.getTranscriptionDb)
   const data = useTranscriptionDataStore((s) => s.data)
@@ -44,9 +46,11 @@ export const TranscriptionSettingsDialogue: React.FC<TranscriptionSettingsDialog
     >
       <DialogContent className="max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Transcription Settings</DialogTitle>
+          <DialogTitle>{isGlobal ? "Global Transcription Settings" : "Transcription Settings"}</DialogTitle>
           <DialogDescription>
-            {`Default transcription settings for "${projectName}" will go here.`}
+            {isGlobal
+              ? "Configure the default transcription settings for all new projects."
+              : `Default transcription settings for "${projectName}" will go here.`}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -37,7 +37,7 @@ export const DEFAULT_ADVANCED_SETTINGS: Omit<AdvancedSettings, "id" | "createdAt
   isMaxCompletionTokensAuto: false,
 }
 
-export const DEFAULT_TRANSCTIPTION_SETTINGS: Pick<Transcription, "selectedMode" | "customInstructions" | "models" | "language" | "selectedUploadId"> = {
+export const DEFAULT_TRANSCRIPTION_SETTINGS: Pick<Transcription, "selectedMode" | "customInstructions" | "models" | "language" | "selectedUploadId"> = {
   selectedMode: "sentence",
   customInstructions: "",
   models: "mitsuko-premium",

--- a/src/constants/global-settings.ts
+++ b/src/constants/global-settings.ts
@@ -1,2 +1,7 @@
 export const GLOBAL_BASIC_SETTINGS_ID = 'global-basic-settings'
 export const GLOBAL_ADVANCED_SETTINGS_ID = 'global-advanced-settings'
+export const GLOBAL_TRANSLATION_BASIC_SETTINGS_ID = 'global-translation-basic-settings'
+export const GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID = 'global-translation-advanced-settings'
+export const GLOBAL_EXTRACTION_BASIC_SETTINGS_ID = 'global-extraction-basic-settings'
+export const GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID = 'global-extraction-advanced-settings'
+export const GLOBAL_TRANSCRIPTION_SETTINGS_ID = 'global-transcription-settings'

--- a/src/contexts/project-context.tsx
+++ b/src/contexts/project-context.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '@/stores/data/use-project-store'
 import { createContext, PropsWithChildren, useEffect } from 'react'
 import { useSettingsStore } from '@/stores/settings/use-settings-store'
 import { useAdvancedSettingsStore } from '@/stores/settings/use-advanced-settings-store'
+import { useTranscriptionDataStore } from '@/stores/data/use-transcription-data-store'
 import { ensureGlobalDefaultsExist } from '@/lib/db/global-settings'
 
 const ProjectStoreContext = createContext(undefined)
@@ -12,6 +13,7 @@ export default function ProjectStoreProvider({ children }: PropsWithChildren) {
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const loadSettings = useSettingsStore((state) => state.loadSettings)
   const loadAdvancedSettings = useAdvancedSettingsStore((state) => state.loadSettings)
+  const loadGlobalTranscription = useTranscriptionDataStore((state) => state.loadGlobalTranscription)
 
   useEffect(() => {
     const init = async () => {
@@ -24,10 +26,11 @@ export default function ProjectStoreProvider({ children }: PropsWithChildren) {
         loadProjects(),
         loadSettings(),
         loadAdvancedSettings(),
+        loadGlobalTranscription(),
       ])
     }
     init()
-  }, [loadProjects, loadSettings, loadAdvancedSettings])
+  }, [loadProjects, loadSettings, loadAdvancedSettings, loadGlobalTranscription])
 
   return (
     <ProjectStoreContext.Provider value={undefined}>

--- a/src/lib/db/db-constructor.ts
+++ b/src/lib/db/db-constructor.ts
@@ -154,6 +154,9 @@ export function generateNewIds(data: DatabaseExport): DatabaseExport {
       defaultExtractionAdvancedSettingsId: newDefaultExtractionAdvancedSettingsId,
       defaultTranscriptionId: newDefaultTranscriptionId,
       isBatch: project.isBatch ?? false,
+      isDefaultTranslationEnabled: typeof project.isDefaultTranslationEnabled === 'boolean' ? project.isDefaultTranslationEnabled : false,
+      isDefaultExtractionEnabled: typeof project.isDefaultExtractionEnabled === 'boolean' ? project.isDefaultExtractionEnabled : false,
+      isDefaultTranscriptionEnabled: typeof project.isDefaultTranscriptionEnabled === 'boolean' ? project.isDefaultTranscriptionEnabled : false,
     }
   })
 
@@ -204,6 +207,9 @@ function projectConstructor(project: Partial<Project>): Project {
     defaultExtractionAdvancedSettingsId: project.defaultExtractionAdvancedSettingsId ?? "",
     defaultTranscriptionId: project.defaultTranscriptionId ?? "",
     isBatch: project.isBatch ?? false,
+    isDefaultTranslationEnabled: typeof project.isDefaultTranslationEnabled === 'boolean' ? project.isDefaultTranslationEnabled : false,
+    isDefaultExtractionEnabled: typeof project.isDefaultExtractionEnabled === 'boolean' ? project.isDefaultExtractionEnabled : false,
+    isDefaultTranscriptionEnabled: typeof project.isDefaultTranscriptionEnabled === 'boolean' ? project.isDefaultTranscriptionEnabled : false,
   }
 }
 

--- a/src/lib/db/db-io.ts
+++ b/src/lib/db/db-io.ts
@@ -2,17 +2,36 @@ import { db } from './db'
 import { DatabaseExport, databaseExportConstructor, generateNewIds } from './db-constructor'
 import { Project, BasicSettings, AdvancedSettings, Transcription } from '@/types/project'
 import { DEFAULT_BASIC_SETTINGS, DEFAULT_ADVANCED_SETTINGS, DEFAULT_TRANSCTIPTION_SETTINGS } from '@/constants/default'
-import { GLOBAL_ADVANCED_SETTINGS_ID, GLOBAL_BASIC_SETTINGS_ID } from '@/constants/global-settings'
+import {
+  GLOBAL_ADVANCED_SETTINGS_ID,
+  GLOBAL_BASIC_SETTINGS_ID,
+  GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID,
+  GLOBAL_EXTRACTION_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID,
+  GLOBAL_TRANSLATION_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSCRIPTION_SETTINGS_ID
+} from '@/constants/global-settings'
 
+const GLOBAL_BASIC_IDS = [
+  GLOBAL_BASIC_SETTINGS_ID,
+  GLOBAL_TRANSLATION_BASIC_SETTINGS_ID,
+  GLOBAL_EXTRACTION_BASIC_SETTINGS_ID,
+]
+
+const GLOBAL_ADVANCED_IDS = [
+  GLOBAL_ADVANCED_SETTINGS_ID,
+  GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID,
+  GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID,
+]
 export async function exportDatabase(): Promise<string> {
   const exportData: DatabaseExport = {
     projects: await db.projects.toArray(),
     translations: await db.translations.toArray(),
-    transcriptions: await db.transcriptions.toArray(),
+    transcriptions: (await db.transcriptions.toArray()).filter(t => t.id !== GLOBAL_TRANSCRIPTION_SETTINGS_ID),
     extractions: await db.extractions.toArray(),
     projectOrders: await db.projectOrders.toArray(),
-    basicSettings: (await db.basicSettings.toArray()).filter(s => s.id !== GLOBAL_BASIC_SETTINGS_ID),
-    advancedSettings: (await db.advancedSettings.toArray()).filter(s => s.id !== GLOBAL_ADVANCED_SETTINGS_ID),
+    basicSettings: (await db.basicSettings.toArray()).filter(s => !GLOBAL_BASIC_IDS.includes(s.id)),
+    advancedSettings: (await db.advancedSettings.toArray()).filter(s => !GLOBAL_ADVANCED_IDS.includes(s.id)),
   }
 
   if (process.env.NODE_ENV === 'development') {
@@ -77,10 +96,10 @@ export async function exportProject(
 
   const basicSettings = (
     await db.basicSettings.bulkGet(Array.from(basicSettingsIds))
-  ).filter((s): s is BasicSettings => s !== undefined && s.id !== GLOBAL_BASIC_SETTINGS_ID)
+  ).filter((s): s is BasicSettings => s !== undefined && !GLOBAL_BASIC_IDS.includes(s.id))
   const advancedSettings = (
     await db.advancedSettings.bulkGet(Array.from(advancedSettingsIds))
-  ).filter((s): s is AdvancedSettings => s !== undefined && s.id !== GLOBAL_ADVANCED_SETTINGS_ID)
+  ).filter((s): s is AdvancedSettings => s !== undefined && !GLOBAL_ADVANCED_IDS.includes(s.id))
 
   const projectOrders = await db.projectOrders.limit(1).toArray()
   const projectOrder =
@@ -236,14 +255,14 @@ export async function importDatabase(jsonString: string, clearExisting: boolean)
         await Promise.all([
           db.projects.clear(),
           db.translations.clear(),
-          db.transcriptions.clear(),
+          db.transcriptions.filter(t => t.id !== GLOBAL_TRANSCRIPTION_SETTINGS_ID).delete(),
           db.extractions.clear(),
           db.projectOrders.clear(),
           db.basicSettings
-            .filter(s => s.id !== GLOBAL_BASIC_SETTINGS_ID)
+            .filter(s => !GLOBAL_BASIC_IDS.includes(s.id))
             .delete(),
           db.advancedSettings
-            .filter(s => s.id !== GLOBAL_ADVANCED_SETTINGS_ID)
+            .filter(s => !GLOBAL_ADVANCED_IDS.includes(s.id))
             .delete()
         ])
 

--- a/src/lib/db/db-io.ts
+++ b/src/lib/db/db-io.ts
@@ -1,7 +1,7 @@
 import { db } from './db'
 import { DatabaseExport, databaseExportConstructor, generateNewIds } from './db-constructor'
 import { Project, BasicSettings, AdvancedSettings, Transcription } from '@/types/project'
-import { DEFAULT_BASIC_SETTINGS, DEFAULT_ADVANCED_SETTINGS, DEFAULT_TRANSCTIPTION_SETTINGS } from '@/constants/default'
+import { DEFAULT_BASIC_SETTINGS, DEFAULT_ADVANCED_SETTINGS, DEFAULT_TRANSCRIPTION_SETTINGS } from '@/constants/default'
 import {
   GLOBAL_ADVANCED_SETTINGS_ID,
   GLOBAL_BASIC_SETTINGS_ID,
@@ -227,7 +227,7 @@ export async function importDatabase(jsonString: string, clearExisting: boolean)
           id: transcriptionId,
           projectId: project.id,
           title: '',
-          ...DEFAULT_TRANSCTIPTION_SETTINGS,
+          ...DEFAULT_TRANSCRIPTION_SETTINGS,
           transcriptionText: '',
           transcriptSubtitles: [],
           words: [],

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -308,6 +308,19 @@ class MyDatabase extends Dexie {
         await projectsTable.update(update.id, update.changes)
       }
     })
+    this.version(24).stores({}).upgrade(async tx => {
+      await tx.table('projects').toCollection().modify(project => {
+        if (typeof project.isDefaultTranslationEnabled === 'undefined') {
+          project.isDefaultTranslationEnabled = false
+        }
+        if (typeof project.isDefaultExtractionEnabled === 'undefined') {
+          project.isDefaultExtractionEnabled = false
+        }
+        if (typeof project.isDefaultTranscriptionEnabled === 'undefined') {
+          project.isDefaultTranscriptionEnabled = false
+        }
+      })
+    })
   }
 }
 

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ADVANCED_SETTINGS, DEFAULT_BASIC_SETTINGS, DEFAULT_TRANSCTIPTION_SETTINGS } from '@/constants/default'
+import { DEFAULT_ADVANCED_SETTINGS, DEFAULT_BASIC_SETTINGS, DEFAULT_TRANSCRIPTION_SETTINGS } from '@/constants/default'
 import { Project, Translation, Transcription, Extraction, ProjectOrder, BasicSettings, AdvancedSettings } from '@/types/project'
 import { CustomInstruction } from '@/types/custom-instruction'
 import Dexie, { Table } from 'dexie'
@@ -289,7 +289,7 @@ class MyDatabase extends Dexie {
             title: '',
             transcriptionText: '',
             transcriptSubtitles: [],
-            ...DEFAULT_TRANSCTIPTION_SETTINGS,
+            ...DEFAULT_TRANSCRIPTION_SETTINGS,
             words: [],
             segments: [],
             createdAt: new Date(),

--- a/src/lib/db/global-settings.ts
+++ b/src/lib/db/global-settings.ts
@@ -55,12 +55,26 @@ export const getOrCreateGlobalAdvancedSettings = async (): Promise<AdvancedSetti
 export const getOrCreateGlobalTranslationBasicSettings = async (): Promise<BasicSettings> => {
   const existing = await getBasicSettings(GLOBAL_TRANSLATION_BASIC_SETTINGS_ID)
   if (existing) return existing
+  
+  const globalBasic = await getGlobalBasicSettings()
+  if (globalBasic) {
+    const { id, createdAt, updatedAt, ...rest } = globalBasic
+    return upsertBasicSettingsWithId(GLOBAL_TRANSLATION_BASIC_SETTINGS_ID, rest)
+  }
+
   return upsertBasicSettingsWithId(GLOBAL_TRANSLATION_BASIC_SETTINGS_ID, { ...DEFAULT_BASIC_SETTINGS })
 }
 
 export const getOrCreateGlobalTranslationAdvancedSettings = async (): Promise<AdvancedSettings> => {
   const existing = await getAdvancedSettings(GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID)
   if (existing) return existing
+  
+  const globalAdvanced = await getGlobalAdvancedSettings()
+  if (globalAdvanced) {
+    const { id, createdAt, updatedAt, ...rest } = globalAdvanced
+    return upsertAdvancedSettingsWithId(GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID, rest)
+  }
+
   return upsertAdvancedSettingsWithId(GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID, { ...DEFAULT_ADVANCED_SETTINGS })
 }
 

--- a/src/lib/db/global-settings.ts
+++ b/src/lib/db/global-settings.ts
@@ -4,7 +4,7 @@ import { DEFAULT_ADVANCED_SETTINGS, DEFAULT_BASIC_SETTINGS } from '@/constants/d
 import { getBasicSettings, getAdvancedSettings } from './settings'
 import { GLOBAL_ADVANCED_SETTINGS_ID, GLOBAL_BASIC_SETTINGS_ID, GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID, GLOBAL_EXTRACTION_BASIC_SETTINGS_ID, GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID, GLOBAL_TRANSLATION_BASIC_SETTINGS_ID, GLOBAL_TRANSCRIPTION_SETTINGS_ID } from '@/constants/global-settings'
 import { Transcription } from '@/types/project'
-import { DEFAULT_TRANSCTIPTION_SETTINGS } from '@/constants/default'
+import { DEFAULT_TRANSCRIPTION_SETTINGS } from '@/constants/default'
 
 export const upsertBasicSettingsWithId = async (
   id: string,
@@ -55,7 +55,7 @@ export const getOrCreateGlobalAdvancedSettings = async (): Promise<AdvancedSetti
 export const getOrCreateGlobalTranslationBasicSettings = async (): Promise<BasicSettings> => {
   const existing = await getBasicSettings(GLOBAL_TRANSLATION_BASIC_SETTINGS_ID)
   if (existing) return existing
-  
+
   const globalBasic = await getGlobalBasicSettings()
   if (globalBasic) {
     const { id, createdAt, updatedAt, ...rest } = globalBasic
@@ -68,7 +68,7 @@ export const getOrCreateGlobalTranslationBasicSettings = async (): Promise<Basic
 export const getOrCreateGlobalTranslationAdvancedSettings = async (): Promise<AdvancedSettings> => {
   const existing = await getAdvancedSettings(GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID)
   if (existing) return existing
-  
+
   const globalAdvanced = await getGlobalAdvancedSettings()
   if (globalAdvanced) {
     const { id, createdAt, updatedAt, ...rest } = globalAdvanced
@@ -93,13 +93,13 @@ export const getOrCreateGlobalExtractionAdvancedSettings = async (): Promise<Adv
 export const getOrCreateGlobalTranscriptionSettings = async (): Promise<Transcription> => {
   const existing = await db.transcriptions.get(GLOBAL_TRANSCRIPTION_SETTINGS_ID)
   if (existing) return existing
-  
+
   const now = new Date()
   const defaultTranscription: Transcription = {
     id: GLOBAL_TRANSCRIPTION_SETTINGS_ID,
     projectId: 'global',
     title: 'Global Transcription Settings',
-    ...DEFAULT_TRANSCTIPTION_SETTINGS,
+    ...DEFAULT_TRANSCRIPTION_SETTINGS,
     transcriptionText: '',
     transcriptSubtitles: [],
     words: [],

--- a/src/lib/db/global-settings.ts
+++ b/src/lib/db/global-settings.ts
@@ -2,7 +2,9 @@ import { db } from './db'
 import { BasicSettings, AdvancedSettings } from '@/types/project'
 import { DEFAULT_ADVANCED_SETTINGS, DEFAULT_BASIC_SETTINGS } from '@/constants/default'
 import { getBasicSettings, getAdvancedSettings } from './settings'
-import { GLOBAL_ADVANCED_SETTINGS_ID, GLOBAL_BASIC_SETTINGS_ID } from '@/constants/global-settings'
+import { GLOBAL_ADVANCED_SETTINGS_ID, GLOBAL_BASIC_SETTINGS_ID, GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID, GLOBAL_EXTRACTION_BASIC_SETTINGS_ID, GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID, GLOBAL_TRANSLATION_BASIC_SETTINGS_ID, GLOBAL_TRANSCRIPTION_SETTINGS_ID } from '@/constants/global-settings'
+import { Transcription } from '@/types/project'
+import { DEFAULT_TRANSCTIPTION_SETTINGS } from '@/constants/default'
 
 export const upsertBasicSettingsWithId = async (
   id: string,
@@ -50,9 +52,59 @@ export const getOrCreateGlobalAdvancedSettings = async (): Promise<AdvancedSetti
   return upsertAdvancedSettingsWithId(GLOBAL_ADVANCED_SETTINGS_ID, { ...DEFAULT_ADVANCED_SETTINGS })
 }
 
+export const getOrCreateGlobalTranslationBasicSettings = async (): Promise<BasicSettings> => {
+  const existing = await getBasicSettings(GLOBAL_TRANSLATION_BASIC_SETTINGS_ID)
+  if (existing) return existing
+  return upsertBasicSettingsWithId(GLOBAL_TRANSLATION_BASIC_SETTINGS_ID, { ...DEFAULT_BASIC_SETTINGS })
+}
+
+export const getOrCreateGlobalTranslationAdvancedSettings = async (): Promise<AdvancedSettings> => {
+  const existing = await getAdvancedSettings(GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID)
+  if (existing) return existing
+  return upsertAdvancedSettingsWithId(GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID, { ...DEFAULT_ADVANCED_SETTINGS })
+}
+
+export const getOrCreateGlobalExtractionBasicSettings = async (): Promise<BasicSettings> => {
+  const existing = await getBasicSettings(GLOBAL_EXTRACTION_BASIC_SETTINGS_ID)
+  if (existing) return existing
+  return upsertBasicSettingsWithId(GLOBAL_EXTRACTION_BASIC_SETTINGS_ID, { ...DEFAULT_BASIC_SETTINGS })
+}
+
+export const getOrCreateGlobalExtractionAdvancedSettings = async (): Promise<AdvancedSettings> => {
+  const existing = await getAdvancedSettings(GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID)
+  if (existing) return existing
+  return upsertAdvancedSettingsWithId(GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID, { ...DEFAULT_ADVANCED_SETTINGS })
+}
+
+export const getOrCreateGlobalTranscriptionSettings = async (): Promise<Transcription> => {
+  const existing = await db.transcriptions.get(GLOBAL_TRANSCRIPTION_SETTINGS_ID)
+  if (existing) return existing
+  
+  const now = new Date()
+  const defaultTranscription: Transcription = {
+    id: GLOBAL_TRANSCRIPTION_SETTINGS_ID,
+    projectId: 'global',
+    title: 'Global Transcription Settings',
+    ...DEFAULT_TRANSCTIPTION_SETTINGS,
+    transcriptionText: '',
+    transcriptSubtitles: [],
+    words: [],
+    segments: [],
+    createdAt: now,
+    updatedAt: now,
+  }
+  await db.transcriptions.put(defaultTranscription)
+  return defaultTranscription
+}
+
 export const ensureGlobalDefaultsExist = async (): Promise<void> => {
   await Promise.all([
     getOrCreateGlobalBasicSettings(),
     getOrCreateGlobalAdvancedSettings(),
+    getOrCreateGlobalTranslationBasicSettings(),
+    getOrCreateGlobalTranslationAdvancedSettings(),
+    getOrCreateGlobalExtractionBasicSettings(),
+    getOrCreateGlobalExtractionAdvancedSettings(),
+    getOrCreateGlobalTranscriptionSettings(),
   ])
 }

--- a/src/lib/db/project.ts
+++ b/src/lib/db/project.ts
@@ -15,6 +15,9 @@ export const createProject = async (name: string, isBatch = false, isDefaultSett
   return db.transaction('rw', [db.projects, db.projectOrders, db.basicSettings, db.advancedSettings, db.transcriptions], async () => {
     const id = crypto.randomUUID()
 
+    // Batch projects always have default settings enabled
+    const enableFlags = isBatch ? true : isDefaultSettingsEnabledDefault
+
     const globalBasic = await getOrCreateGlobalBasicSettings()
     const basicTemplate = stripMeta(globalBasic)
     const basicSettings = await createBasicSettings(basicTemplate)
@@ -72,9 +75,9 @@ export const createProject = async (name: string, isBatch = false, isDefaultSett
       createdAt: new Date(),
       updatedAt: new Date(),
       isBatch,
-      isDefaultTranslationEnabled: isDefaultSettingsEnabledDefault,
-      isDefaultExtractionEnabled: isDefaultSettingsEnabledDefault,
-      isDefaultTranscriptionEnabled: isDefaultSettingsEnabledDefault,
+      isDefaultTranslationEnabled: enableFlags,
+      isDefaultExtractionEnabled: enableFlags,
+      isDefaultTranscriptionEnabled: enableFlags,
     }
 
     await db.projects.add(project)

--- a/src/lib/db/project.ts
+++ b/src/lib/db/project.ts
@@ -2,7 +2,7 @@ import { Project, Transcription } from "@/types/project"
 import { db } from "./db"
 import { createBasicSettings, createAdvancedSettings } from "./settings"
 import { getOrCreateGlobalBasicSettings, getOrCreateGlobalAdvancedSettings, getOrCreateGlobalTranslationBasicSettings, getOrCreateGlobalTranslationAdvancedSettings, getOrCreateGlobalExtractionBasicSettings, getOrCreateGlobalExtractionAdvancedSettings, getOrCreateGlobalTranscriptionSettings } from "./global-settings"
-import { DEFAULT_TRANSCTIPTION_SETTINGS } from "@/constants/default"
+import { DEFAULT_TRANSCRIPTION_SETTINGS } from "@/constants/default"
 
 const stripMeta = <T extends { id: string; createdAt: Date; updatedAt: Date }>(obj: T) => {
   const { id, createdAt, updatedAt, ...rest } = obj
@@ -18,20 +18,20 @@ export const createProject = async (name: string, isBatch = false, isDefaultSett
     const globalBasic = await getOrCreateGlobalBasicSettings()
     const basicTemplate = stripMeta(globalBasic)
     const basicSettings = await createBasicSettings(basicTemplate)
-    
+
     const globalTranslationBasic = await getOrCreateGlobalTranslationBasicSettings()
     const translationBasicSettings = await createBasicSettings(stripMeta(globalTranslationBasic))
-    
+
     const globalExtractionBasic = await getOrCreateGlobalExtractionBasicSettings()
     const extractionBasicSettings = await createBasicSettings(stripMeta(globalExtractionBasic))
 
     const globalAdvanced = await getOrCreateGlobalAdvancedSettings()
     const advancedTemplate = stripMeta(globalAdvanced)
     const advancedSettings = await createAdvancedSettings(advancedTemplate)
-    
+
     const globalTranslationAdvanced = await getOrCreateGlobalTranslationAdvancedSettings()
     const translationAdvancedSettings = await createAdvancedSettings(stripMeta(globalTranslationAdvanced))
-    
+
     const globalExtractionAdvanced = await getOrCreateGlobalExtractionAdvancedSettings()
     const extractionAdvancedSettings = await createAdvancedSettings(stripMeta(globalExtractionAdvanced))
 
@@ -42,7 +42,7 @@ export const createProject = async (name: string, isBatch = false, isDefaultSett
       id: defaultTranscriptionId,
       projectId: id,
       title: '',
-      ...DEFAULT_TRANSCTIPTION_SETTINGS,
+      ...DEFAULT_TRANSCRIPTION_SETTINGS,
       models: globalTranscriptionSettings.models,
       language: globalTranscriptionSettings.language,
       selectedMode: globalTranscriptionSettings.selectedMode,

--- a/src/lib/db/project.ts
+++ b/src/lib/db/project.ts
@@ -1,7 +1,7 @@
 import { Project, Transcription } from "@/types/project"
 import { db } from "./db"
 import { createBasicSettings, createAdvancedSettings } from "./settings"
-import { getOrCreateGlobalBasicSettings, getOrCreateGlobalAdvancedSettings } from "./global-settings"
+import { getOrCreateGlobalBasicSettings, getOrCreateGlobalAdvancedSettings, getOrCreateGlobalTranslationBasicSettings, getOrCreateGlobalTranslationAdvancedSettings, getOrCreateGlobalExtractionBasicSettings, getOrCreateGlobalExtractionAdvancedSettings, getOrCreateGlobalTranscriptionSettings } from "./global-settings"
 import { DEFAULT_TRANSCTIPTION_SETTINGS } from "@/constants/default"
 
 const stripMeta = <T extends { id: string; createdAt: Date; updatedAt: Date }>(obj: T) => {
@@ -18,22 +18,35 @@ export const createProject = async (name: string, isBatch = false): Promise<Proj
     const globalBasic = await getOrCreateGlobalBasicSettings()
     const basicTemplate = stripMeta(globalBasic)
     const basicSettings = await createBasicSettings(basicTemplate)
-    const translationBasicSettings = await createBasicSettings(stripMeta(basicSettings))
-    const extractionBasicSettings = await createBasicSettings(stripMeta(basicSettings))
+    
+    const globalTranslationBasic = await getOrCreateGlobalTranslationBasicSettings()
+    const translationBasicSettings = await createBasicSettings(stripMeta(globalTranslationBasic))
+    
+    const globalExtractionBasic = await getOrCreateGlobalExtractionBasicSettings()
+    const extractionBasicSettings = await createBasicSettings(stripMeta(globalExtractionBasic))
 
     const globalAdvanced = await getOrCreateGlobalAdvancedSettings()
     const advancedTemplate = stripMeta(globalAdvanced)
     const advancedSettings = await createAdvancedSettings(advancedTemplate)
-    const translationAdvancedSettings = await createAdvancedSettings(stripMeta(advancedSettings))
-    const extractionAdvancedSettings = await createAdvancedSettings(stripMeta(advancedSettings))
+    
+    const globalTranslationAdvanced = await getOrCreateGlobalTranslationAdvancedSettings()
+    const translationAdvancedSettings = await createAdvancedSettings(stripMeta(globalTranslationAdvanced))
+    
+    const globalExtractionAdvanced = await getOrCreateGlobalExtractionAdvancedSettings()
+    const extractionAdvancedSettings = await createAdvancedSettings(stripMeta(globalExtractionAdvanced))
 
     // Create default transcription for batch settings
+    const globalTranscriptionSettings = await getOrCreateGlobalTranscriptionSettings()
     const defaultTranscriptionId = crypto.randomUUID()
     const defaultTranscription: Transcription = {
       id: defaultTranscriptionId,
       projectId: id,
       title: '',
       ...DEFAULT_TRANSCTIPTION_SETTINGS,
+      models: globalTranscriptionSettings.models,
+      language: globalTranscriptionSettings.language,
+      selectedMode: globalTranscriptionSettings.selectedMode,
+      customInstructions: globalTranscriptionSettings.customInstructions,
       transcriptionText: '',
       transcriptSubtitles: [],
       words: [],

--- a/src/lib/db/project.ts
+++ b/src/lib/db/project.ts
@@ -11,12 +11,12 @@ const stripMeta = <T extends { id: string; createdAt: Date; updatedAt: Date }>(o
 }
 
 // Project CRUD functions
-export const createProject = async (name: string, isBatch = false, isDefaultSettingsEnabledDefault = false): Promise<Project> => {
+export const createProject = async (name: string, isBatch = false, isAutoEnableProjectSettings = false): Promise<Project> => {
   return db.transaction('rw', [db.projects, db.projectOrders, db.basicSettings, db.advancedSettings, db.transcriptions], async () => {
     const id = crypto.randomUUID()
 
     // Batch projects always have default settings enabled
-    const enableFlags = isBatch ? true : isDefaultSettingsEnabledDefault
+    const enableFlags = isBatch ? true : isAutoEnableProjectSettings
 
     const globalBasic = await getOrCreateGlobalBasicSettings()
     const basicTemplate = stripMeta(globalBasic)

--- a/src/lib/db/project.ts
+++ b/src/lib/db/project.ts
@@ -11,7 +11,7 @@ const stripMeta = <T extends { id: string; createdAt: Date; updatedAt: Date }>(o
 }
 
 // Project CRUD functions
-export const createProject = async (name: string, isBatch = false): Promise<Project> => {
+export const createProject = async (name: string, isBatch = false, isDefaultSettingsEnabledDefault = false): Promise<Project> => {
   return db.transaction('rw', [db.projects, db.projectOrders, db.basicSettings, db.advancedSettings, db.transcriptions], async () => {
     const id = crypto.randomUUID()
 
@@ -72,6 +72,9 @@ export const createProject = async (name: string, isBatch = false): Promise<Proj
       createdAt: new Date(),
       updatedAt: new Date(),
       isBatch,
+      isDefaultTranslationEnabled: isDefaultSettingsEnabledDefault,
+      isDefaultExtractionEnabled: isDefaultSettingsEnabledDefault,
+      isDefaultTranscriptionEnabled: isDefaultSettingsEnabledDefault,
     }
 
     await db.projects.add(project)

--- a/src/lib/db/transcription.ts
+++ b/src/lib/db/transcription.ts
@@ -1,6 +1,6 @@
 import { Transcription } from "@/types/project"
 import { db } from "./db"
-import { DEFAULT_TRANSCTIPTION_SETTINGS } from "@/constants/default"
+import { DEFAULT_TRANSCRIPTION_SETTINGS } from "@/constants/default"
 
 interface TranscriptionData {
   title: Transcription["title"]
@@ -30,7 +30,7 @@ export const createTranscription = async (
     const transcription: Transcription = {
       id,
       projectId,
-      ...DEFAULT_TRANSCTIPTION_SETTINGS,
+      ...DEFAULT_TRANSCRIPTION_SETTINGS,
       ...newData,
       createdAt: new Date(),
       updatedAt: new Date()

--- a/src/lib/db/transcription.ts
+++ b/src/lib/db/transcription.ts
@@ -7,6 +7,9 @@ interface TranscriptionData {
   transcriptionText: Transcription["transcriptionText"]
   transcriptSubtitles: Transcription["transcriptSubtitles"]
   models?: Transcription["models"]
+  language?: Transcription["language"]
+  selectedMode?: Transcription["selectedMode"]
+  customInstructions?: Transcription["customInstructions"]
   words?: Transcription["words"]
   segments?: Transcription["segments"]
 }

--- a/src/stores/data/use-extraction-data-store.ts
+++ b/src/stores/data/use-extraction-data-store.ts
@@ -60,14 +60,8 @@ export const useExtractionDataStore = create<ExtractionDataStore>((set, get) => 
       const project = await db.projects.get(projectId)
       if (!project) throw new Error('Project not found')
 
-      const isSeparateSettingsEnabled = useLocalSettingsStore.getState().isSeparateSettingsEnabled
-
-      const basicSettingsId = isSeparateSettingsEnabled
-        ? (project.defaultExtractionBasicSettingsId || project.defaultBasicSettingsId)
-        : project.defaultBasicSettingsId
-      const advancedSettingsId = isSeparateSettingsEnabled
-        ? (project.defaultExtractionAdvancedSettingsId || project.defaultAdvancedSettingsId)
-        : project.defaultAdvancedSettingsId
+      const basicSettingsId = project.defaultExtractionBasicSettingsId
+      const advancedSettingsId = project.defaultExtractionAdvancedSettingsId
 
       const bsFromDb = await getBasicSettings(basicSettingsId)
       const adsFromDb = await getAdvancedSettings(advancedSettingsId)

--- a/src/stores/data/use-extraction-data-store.ts
+++ b/src/stores/data/use-extraction-data-store.ts
@@ -12,6 +12,7 @@ import { useAdvancedSettingsStore } from "@/stores/settings/use-advanced-setting
 import { db } from "@/lib/db/db"
 import { DEFAULT_BASIC_SETTINGS, DEFAULT_ADVANCED_SETTINGS } from "@/constants/default"
 import { useLocalSettingsStore } from "@/stores/use-local-settings-store"
+import { GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID, GLOBAL_EXTRACTION_BASIC_SETTINGS_ID } from "@/constants/global-settings"
 
 export interface ExtractionDataStore {
   currentId: string | null
@@ -60,8 +61,12 @@ export const useExtractionDataStore = create<ExtractionDataStore>((set, get) => 
       const project = await db.projects.get(projectId)
       if (!project) throw new Error('Project not found')
 
-      const basicSettingsId = project.defaultExtractionBasicSettingsId
-      const advancedSettingsId = project.defaultExtractionAdvancedSettingsId
+      const basicSettingsId = project.isDefaultExtractionEnabled
+        ? project.defaultExtractionBasicSettingsId
+        : GLOBAL_EXTRACTION_BASIC_SETTINGS_ID
+      const advancedSettingsId = project.isDefaultExtractionEnabled
+        ? project.defaultExtractionAdvancedSettingsId
+        : GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID
 
       const bsFromDb = await getBasicSettings(basicSettingsId)
       const adsFromDb = await getAdvancedSettings(advancedSettingsId)

--- a/src/stores/data/use-extraction-data-store.ts
+++ b/src/stores/data/use-extraction-data-store.ts
@@ -61,10 +61,10 @@ export const useExtractionDataStore = create<ExtractionDataStore>((set, get) => 
       const project = await db.projects.get(projectId)
       if (!project) throw new Error('Project not found')
 
-      const basicSettingsId = project.isDefaultExtractionEnabled
+      const basicSettingsId = (project.isBatch || project.isDefaultExtractionEnabled)
         ? project.defaultExtractionBasicSettingsId
         : GLOBAL_EXTRACTION_BASIC_SETTINGS_ID
-      const advancedSettingsId = project.isDefaultExtractionEnabled
+      const advancedSettingsId = (project.isBatch || project.isDefaultExtractionEnabled)
         ? project.defaultExtractionAdvancedSettingsId
         : GLOBAL_EXTRACTION_ADVANCED_SETTINGS_ID
 

--- a/src/stores/data/use-project-store.ts
+++ b/src/stores/data/use-project-store.ts
@@ -91,8 +91,8 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   createProject: async (name, isBatch = false) => {
     set({ loading: true })
     try {
-      const isDefaultSettingsEnabledDefault = useLocalSettingsStore.getState().isDefaultSettingsEnabledDefault
-      const newProject = await createProjectDB(name, isBatch, isDefaultSettingsEnabledDefault)
+      const isAutoEnableProjectSettings = useLocalSettingsStore.getState().isAutoEnableProjectSettings
+      const newProject = await createProjectDB(name, isBatch, isAutoEnableProjectSettings)
 
       // upsert associated settings into stores
       const settingsStore = useSettingsStore.getState()

--- a/src/stores/data/use-project-store.ts
+++ b/src/stores/data/use-project-store.ts
@@ -150,6 +150,9 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
         projects: state.projects.map(p =>
           p.id === id ? updatedProject : p
         ),
+        currentProject: state.currentProject?.id === id
+          ? updatedProject
+          : state.currentProject,
         loading: false
       }))
       return updatedProject

--- a/src/stores/data/use-project-store.ts
+++ b/src/stores/data/use-project-store.ts
@@ -21,6 +21,7 @@ import { SubtitleTranslated } from "@/types/subtitles"
 import { deleteTranslation } from "@/lib/db/translation"
 import { deleteExtraction } from "@/lib/db/extraction"
 import { deleteTranscription } from "@/lib/db/transcription"
+import { useLocalSettingsStore } from "../use-local-settings-store"
 
 interface ProjectStore {
   currentProject: Project | null
@@ -90,7 +91,8 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   createProject: async (name, isBatch = false) => {
     set({ loading: true })
     try {
-      const newProject = await createProjectDB(name, isBatch)
+      const isDefaultSettingsEnabledDefault = useLocalSettingsStore.getState().isDefaultSettingsEnabledDefault
+      const newProject = await createProjectDB(name, isBatch, isDefaultSettingsEnabledDefault)
 
       // upsert associated settings into stores
       const settingsStore = useSettingsStore.getState()

--- a/src/stores/data/use-transcription-data-store.ts
+++ b/src/stores/data/use-transcription-data-store.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/db/transcription"
 import { db } from "@/lib/db/db"
 import { Subtitle } from "@/types/subtitles"
-import { DEFAULT_TRANSCTIPTION_SETTINGS } from "@/constants/default"
+import { DEFAULT_TRANSCRIPTION_SETTINGS } from "@/constants/default"
 
 export type TranscriptionSettingKey = 'language' | 'selectedMode' | 'customInstructions' | 'models'
 
@@ -111,16 +111,16 @@ export const useTranscriptionDataStore = create<TranscriptionDataStore>((set, ge
     return get().data[id]?.transcriptSubtitles ?? []
   },
   getSelectedMode: (id) => {
-    return get().data[id]?.selectedMode ?? DEFAULT_TRANSCTIPTION_SETTINGS.selectedMode
+    return get().data[id]?.selectedMode ?? DEFAULT_TRANSCRIPTION_SETTINGS.selectedMode
   },
   getLanguage: (id) => {
-    return get().data[id]?.language ?? DEFAULT_TRANSCTIPTION_SETTINGS.language
+    return get().data[id]?.language ?? DEFAULT_TRANSCRIPTION_SETTINGS.language
   },
   getCustomInstructions: (id) => {
-    return get().data[id]?.customInstructions ?? DEFAULT_TRANSCTIPTION_SETTINGS.customInstructions
+    return get().data[id]?.customInstructions ?? DEFAULT_TRANSCRIPTION_SETTINGS.customInstructions
   },
   getModels: (id) => {
-    return get().data[id]?.models ?? DEFAULT_TRANSCTIPTION_SETTINGS.models
+    return get().data[id]?.models ?? DEFAULT_TRANSCRIPTION_SETTINGS.models
   },
   getWords: (id) => {
     return get().data[id]?.words ?? []
@@ -129,7 +129,7 @@ export const useTranscriptionDataStore = create<TranscriptionDataStore>((set, ge
     return get().data[id]?.segments ?? []
   },
   getSelectedUploadId: (id) => {
-    return get().data[id]?.selectedUploadId ?? DEFAULT_TRANSCTIPTION_SETTINGS.selectedUploadId
+    return get().data[id]?.selectedUploadId ?? DEFAULT_TRANSCRIPTION_SETTINGS.selectedUploadId
   },
   // setters implementation
   setCurrentId: (id) => set({ currentId: id }),
@@ -253,7 +253,7 @@ export const useTranscriptionDataStore = create<TranscriptionDataStore>((set, ge
 
     // Update target transcription in database
     const result = await updateDB(targetId, changes)
-    
+
     // Update local state
     set(state => ({
       data: {

--- a/src/stores/data/use-transcription-data-store.ts
+++ b/src/stores/data/use-transcription-data-store.ts
@@ -16,6 +16,8 @@ export type TranscriptionSettingKey = 'language' | 'selectedMode' | 'customInstr
 interface TranscriptionDataStore {
   currentId: string | null
   data: Record<string, Transcription>
+  // Init
+  loadGlobalTranscription: () => Promise<void>
   // CRUD methods
   createTranscriptionDb: (projectId: string, data: Parameters<typeof createDB>[1]) => Promise<Transcription>
   getTranscriptionDb: (transcriptionId: string, skipStoreUpdate?: boolean) => Promise<Transcription | undefined>
@@ -58,6 +60,16 @@ interface TranscriptionDataStore {
 export const useTranscriptionDataStore = create<TranscriptionDataStore>((set, get) => ({
   currentId: null,
   data: {},
+  loadGlobalTranscription: async () => {
+    try {
+      const globalTranscription = await getDB(GLOBAL_TRANSCRIPTION_SETTINGS_ID)
+      if (globalTranscription) {
+        set(state => ({ data: { ...state.data, [GLOBAL_TRANSCRIPTION_SETTINGS_ID]: globalTranscription } }))
+      }
+    } catch (error) {
+      console.error("Failed to load global transcription", error)
+    }
+  },
   // CRUD methods
   createTranscriptionDb: async (projectId, data) => {
     let resolvedData = { ...data }

--- a/src/stores/data/use-transcription-data-store.ts
+++ b/src/stores/data/use-transcription-data-store.ts
@@ -9,6 +9,7 @@ import {
 import { db } from "@/lib/db/db"
 import { Subtitle } from "@/types/subtitles"
 import { DEFAULT_TRANSCRIPTION_SETTINGS } from "@/constants/default"
+import { GLOBAL_TRANSCRIPTION_SETTINGS_ID } from "@/constants/global-settings"
 
 export type TranscriptionSettingKey = 'language' | 'selectedMode' | 'customInstructions' | 'models'
 
@@ -59,7 +60,35 @@ export const useTranscriptionDataStore = create<TranscriptionDataStore>((set, ge
   data: {},
   // CRUD methods
   createTranscriptionDb: async (projectId, data) => {
-    const transcription = await createDB(projectId, data)
+    let resolvedData = { ...data }
+
+    // Auto-resolve defaults if not explicitly provided
+    if (
+      resolvedData.language === undefined ||
+      resolvedData.models === undefined ||
+      resolvedData.selectedMode === undefined ||
+      resolvedData.customInstructions === undefined
+    ) {
+      const project = await db.projects.get(projectId)
+      if (project) {
+        const defaultId = project.isDefaultTranscriptionEnabled
+          ? project.defaultTranscriptionId
+          : GLOBAL_TRANSCRIPTION_SETTINGS_ID
+
+        const defaultSettings = await getDB(defaultId)
+        if (defaultSettings) {
+          resolvedData = {
+            ...resolvedData,
+            language: resolvedData.language ?? defaultSettings.language,
+            models: resolvedData.models ?? defaultSettings.models,
+            selectedMode: resolvedData.selectedMode ?? defaultSettings.selectedMode,
+            customInstructions: resolvedData.customInstructions ?? defaultSettings.customInstructions,
+          }
+        }
+      }
+    }
+
+    const transcription = await createDB(projectId, resolvedData)
     set(state => ({ data: { ...state.data, [transcription.id]: transcription } }))
     return transcription
   },

--- a/src/stores/data/use-transcription-data-store.ts
+++ b/src/stores/data/use-transcription-data-store.ts
@@ -83,7 +83,7 @@ export const useTranscriptionDataStore = create<TranscriptionDataStore>((set, ge
     ) {
       const project = await db.projects.get(projectId)
       if (project) {
-        const defaultId = project.isDefaultTranscriptionEnabled
+        const defaultId = (project.isBatch || project.isDefaultTranscriptionEnabled)
           ? project.defaultTranscriptionId
           : GLOBAL_TRANSCRIPTION_SETTINGS_ID
 

--- a/src/stores/data/use-translation-data-store.ts
+++ b/src/stores/data/use-translation-data-store.ts
@@ -59,10 +59,10 @@ export const useTranslationDataStore = create<TranslationDataStore>((set, get) =
       const project = await db.projects.get(projectId)
       if (!project) throw new Error('Project not found')
 
-      const basicSettingsId = project.isDefaultTranslationEnabled
+      const basicSettingsId = (project.isBatch || project.isDefaultTranslationEnabled)
         ? project.defaultTranslationBasicSettingsId
         : GLOBAL_TRANSLATION_BASIC_SETTINGS_ID
-      const advancedSettingsId = project.isDefaultTranslationEnabled
+      const advancedSettingsId = (project.isBatch || project.isDefaultTranslationEnabled)
         ? project.defaultTranslationAdvancedSettingsId
         : GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID
 

--- a/src/stores/data/use-translation-data-store.ts
+++ b/src/stores/data/use-translation-data-store.ts
@@ -58,14 +58,8 @@ export const useTranslationDataStore = create<TranslationDataStore>((set, get) =
       const project = await db.projects.get(projectId)
       if (!project) throw new Error('Project not found')
 
-      const isSeparateSettingsEnabled = useLocalSettingsStore.getState().isSeparateSettingsEnabled
-
-      const basicSettingsId = isSeparateSettingsEnabled
-        ? (project.defaultTranslationBasicSettingsId || project.defaultBasicSettingsId)
-        : project.defaultBasicSettingsId
-      const advancedSettingsId = isSeparateSettingsEnabled
-        ? (project.defaultTranslationAdvancedSettingsId || project.defaultAdvancedSettingsId)
-        : project.defaultAdvancedSettingsId
+      const basicSettingsId = project.defaultTranslationBasicSettingsId
+      const advancedSettingsId = project.defaultTranslationAdvancedSettingsId
 
       const bsFromDb = await getBasicSettings(basicSettingsId)
       const adsFromDb = await getAdvancedSettings(advancedSettingsId)

--- a/src/stores/data/use-translation-data-store.ts
+++ b/src/stores/data/use-translation-data-store.ts
@@ -13,6 +13,7 @@ import { useAdvancedSettingsStore } from "@/stores/settings/use-advanced-setting
 import { db } from "@/lib/db/db"
 import { DEFAULT_BASIC_SETTINGS, DEFAULT_ADVANCED_SETTINGS } from "@/constants/default"
 import { useLocalSettingsStore } from "@/stores/use-local-settings-store"
+import { GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID, GLOBAL_TRANSLATION_BASIC_SETTINGS_ID } from "@/constants/global-settings"
 
 export interface TranslationDataStore {
   currentId: string | null
@@ -58,8 +59,12 @@ export const useTranslationDataStore = create<TranslationDataStore>((set, get) =
       const project = await db.projects.get(projectId)
       if (!project) throw new Error('Project not found')
 
-      const basicSettingsId = project.defaultTranslationBasicSettingsId
-      const advancedSettingsId = project.defaultTranslationAdvancedSettingsId
+      const basicSettingsId = project.isDefaultTranslationEnabled
+        ? project.defaultTranslationBasicSettingsId
+        : GLOBAL_TRANSLATION_BASIC_SETTINGS_ID
+      const advancedSettingsId = project.isDefaultTranslationEnabled
+        ? project.defaultTranslationAdvancedSettingsId
+        : GLOBAL_TRANSLATION_ADVANCED_SETTINGS_ID
 
       const bsFromDb = await getBasicSettings(basicSettingsId)
       const adsFromDb = await getAdvancedSettings(advancedSettingsId)

--- a/src/stores/use-local-settings-store.ts
+++ b/src/stores/use-local-settings-store.ts
@@ -15,7 +15,7 @@ interface LocalSettingsStore {
   isSubtitleCleanupEnabled: boolean
   isDeleteAfterTranscription: boolean
   isSubtitlePerformanceModeEnabled: boolean
-  isDefaultSettingsEnabledDefault: boolean
+  isAutoEnableProjectSettings: boolean
 
   addApiConfig: (config: CustomApiConfig) => void
   updateApiConfig: (index: number, updates: Partial<CustomApiConfig>) => Promise<void>
@@ -27,7 +27,7 @@ interface LocalSettingsStore {
   setIsSubtitleCleanupEnabled: (enabled: boolean) => void
   setIsDeleteAfterTranscription: (enabled: boolean) => void
   setIsSubtitlePerformanceModeEnabled: (enabled: boolean) => void
-  setIsDefaultSettingsEnabledDefault: (enabled: boolean) => void
+  setIsAutoEnableProjectSettings: (enabled: boolean) => void
 }
 
 export const useLocalSettingsStore = create<LocalSettingsStore>()(
@@ -40,7 +40,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       isSubtitleCleanupEnabled: true,
       isDeleteAfterTranscription: true,
       isSubtitlePerformanceModeEnabled: true,
-      isDefaultSettingsEnabledDefault: false,
+      isAutoEnableProjectSettings: false,
 
       addApiConfig: (config) =>
         set((state) => ({
@@ -81,7 +81,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       setIsSubtitleCleanupEnabled: (enabled) => set({ isSubtitleCleanupEnabled: enabled }),
       setIsDeleteAfterTranscription: (enabled) => set({ isDeleteAfterTranscription: enabled }),
       setIsSubtitlePerformanceModeEnabled: (enabled) => set({ isSubtitlePerformanceModeEnabled: enabled }),
-      setIsDefaultSettingsEnabledDefault: (enabled) => set({ isDefaultSettingsEnabledDefault: enabled }),
+      setIsAutoEnableProjectSettings: (enabled) => set({ isAutoEnableProjectSettings: enabled }),
     }),
     {
       name: "api-settings-storage",

--- a/src/stores/use-local-settings-store.ts
+++ b/src/stores/use-local-settings-store.ts
@@ -15,6 +15,7 @@ interface LocalSettingsStore {
   isSubtitleCleanupEnabled: boolean
   isDeleteAfterTranscription: boolean
   isSubtitlePerformanceModeEnabled: boolean
+  isDefaultSettingsEnabledDefault: boolean
 
   addApiConfig: (config: CustomApiConfig) => void
   updateApiConfig: (index: number, updates: Partial<CustomApiConfig>) => Promise<void>
@@ -26,6 +27,7 @@ interface LocalSettingsStore {
   setIsSubtitleCleanupEnabled: (enabled: boolean) => void
   setIsDeleteAfterTranscription: (enabled: boolean) => void
   setIsSubtitlePerformanceModeEnabled: (enabled: boolean) => void
+  setIsDefaultSettingsEnabledDefault: (enabled: boolean) => void
 }
 
 export const useLocalSettingsStore = create<LocalSettingsStore>()(
@@ -38,6 +40,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       isSubtitleCleanupEnabled: true,
       isDeleteAfterTranscription: true,
       isSubtitlePerformanceModeEnabled: true,
+      isDefaultSettingsEnabledDefault: false,
 
       addApiConfig: (config) =>
         set((state) => ({
@@ -78,6 +81,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       setIsSubtitleCleanupEnabled: (enabled) => set({ isSubtitleCleanupEnabled: enabled }),
       setIsDeleteAfterTranscription: (enabled) => set({ isDeleteAfterTranscription: enabled }),
       setIsSubtitlePerformanceModeEnabled: (enabled) => set({ isSubtitlePerformanceModeEnabled: enabled }),
+      setIsDefaultSettingsEnabledDefault: (enabled) => set({ isDefaultSettingsEnabledDefault: enabled }),
     }),
     {
       name: "api-settings-storage",

--- a/src/stores/use-local-settings-store.ts
+++ b/src/stores/use-local-settings-store.ts
@@ -11,7 +11,6 @@ interface LocalSettingsStore {
   customApiConfigs: CustomApiConfig[]
   selectedApiConfigIndex: number | null
   isThirdPartyModelEnabled: boolean
-  isSeparateSettingsEnabled: boolean
   isAutoTemperatureEnabled: boolean
   isSubtitleCleanupEnabled: boolean
   isDeleteAfterTranscription: boolean
@@ -23,7 +22,6 @@ interface LocalSettingsStore {
   selectApiConfig: (index: number | null) => void
 
   toggleThirdPartyModel: () => void
-  setIsSeparateSettingsEnabled: (enabled: boolean) => void
   setIsAutoTemperatureEnabled: (enabled: boolean) => void
   setIsSubtitleCleanupEnabled: (enabled: boolean) => void
   setIsDeleteAfterTranscription: (enabled: boolean) => void
@@ -36,7 +34,6 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       customApiConfigs: [],
       selectedApiConfigIndex: null,
       isThirdPartyModelEnabled: false,
-      isSeparateSettingsEnabled: false,
       isAutoTemperatureEnabled: true,
       isSubtitleCleanupEnabled: true,
       isDeleteAfterTranscription: true,
@@ -77,7 +74,6 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       selectApiConfig: (index) => set({ selectedApiConfigIndex: index }),
 
       toggleThirdPartyModel: () => set((state) => ({ isThirdPartyModelEnabled: !state.isThirdPartyModelEnabled })),
-      setIsSeparateSettingsEnabled: (enabled) => set({ isSeparateSettingsEnabled: enabled }),
       setIsAutoTemperatureEnabled: (enabled) => set({ isAutoTemperatureEnabled: enabled }),
       setIsSubtitleCleanupEnabled: (enabled) => set({ isSubtitleCleanupEnabled: enabled }),
       setIsDeleteAfterTranscription: (enabled) => set({ isDeleteAfterTranscription: enabled }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -28,6 +28,9 @@ export interface Project {
   createdAt: Date
   updatedAt: Date
   isBatch: boolean // Indicates whether this project is a batch-type project
+  isDefaultTranslationEnabled: boolean
+  isDefaultExtractionEnabled: boolean
+  isDefaultTranscriptionEnabled: boolean
 }
 
 export interface Translation {


### PR DESCRIPTION
## Description
This PR refactors the settings architecture to introduce distinct, independent settings for Translation, Extraction, and Transcription. It removes the old, unified "separate settings toggle" and replaces it with granular, project-specific default settings toggles. It also improves the UI/UX for managing these settings globally and within projects.

## Changes Included
### ✨ Features & Refactorings
- **Distinct Settings Architecture**: Replaced the overarching settings toggle with distinct global settings for translation, extraction, and transcription.
- **Granular Project Layouts**: Introduced project-specific default settings toggles for translation, extraction, and transcription, allowing fine-grained control over default configurations.
- **Data Migration**: Existing global settings are now appropriately initialized into the new global translation settings.
- **UI Enhancements**: 
  - Restructured the User Settings panel, moving the global settings buttons to the content section with better descriptions.
  - Added a `Settings2` icon to the global settings button for better discoverability.
  - Added meaningful icons and labels to the action buttons inside `project-main`.
  - Added a "Reset All" option to the transcription settings dialogue to quickly revert to defaults. 
  - Renamed multiple setting labels and clarified new project auto-enablement descriptions for a better user experience.

### 🐛 Bug Fixes
- **State Sync**: Fixed an issue where the `currentProject` in the Zustand store wouldn't update if the modified project matched the currently selected one.
- **Typo Fix**: Corrected a consistent typo in the `DEFAULT_TRANSCRIPTION_SETTINGS` constant name across the codebase.

## Impact
- **Settings Store**: Simplifies state management by isolating domain-specific preferences.
- **UI Architecture**: More declarative UI flow without leaking overarching toggles into independent translation/transcription settings components.
